### PR TITLE
Leader revocation

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ElectionContext.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ElectionContext.java
@@ -22,6 +22,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -63,7 +64,7 @@ public abstract class ElectionContext implements Closeable {
   final ZkNodeProps leaderProps;
   final String id;
   final String leaderPath;
-  volatile String leaderSeqPath;
+  final AtomicReference<String> leaderSeqPath = new AtomicReference<>();
   private SolrZkClient zkClient;
 
   public ElectionContext(final String coreNodeName,
@@ -80,13 +81,14 @@ public abstract class ElectionContext implements Closeable {
   }
   
   public void cancelElection() throws InterruptedException, KeeperException {
-    if (leaderSeqPath != null) {
+    String path = leaderSeqPath.getAndSet(null);
+    if (path != null) {
       try {
-        log.info("Canceling election {}", leaderSeqPath);
-        zkClient.delete(leaderSeqPath, -1, true);
+        log.info("Canceling election {}", path);
+        zkClient.delete(path, -1, true);
       } catch (NoNodeException e) {
         // fine
-        log.info("cancelElection did not find election node to remove {}", leaderSeqPath);
+        log.info("cancelElection did not find election node to remove {}", path);
       }
     } else {
       log.info("cancelElection skipped as this context has not been initialized");
@@ -95,16 +97,14 @@ public abstract class ElectionContext implements Closeable {
 
   abstract void runLeaderProcess(boolean weAreReplacement, int pauseBeforeStartMs) throws KeeperException, InterruptedException, IOException;
 
+  abstract ElectionContext copy();
+
   public void checkIfIamLeaderFired() {}
 
   public void joinedElectionFired() {}
-
-  public  ElectionContext copy(){
-    throw new UnsupportedOperationException("copy");
-  }
 }
 
-class ShardLeaderElectionContextBase extends ElectionContext {
+abstract class ShardLeaderElectionContextBase extends ElectionContext {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   protected final SolrZkClient zkClient;
   protected String shardId;
@@ -179,6 +179,11 @@ class ShardLeaderElectionContextBase extends ElectionContext {
     ZkCmdExecutor zcmd = new ZkCmdExecutor(30000);
     zcmd.ensureExists(parent, zkClient);
     final byte[] json = Utils.toJSON(leaderProps);
+    final String path = leaderSeqPath.get();
+    if (path == null) {
+      // concurrently cancelled; just bail
+      return;
+    }
     try {
       RetryUtil.retryOnThrowable(NodeExistsException.class, 60000, 5000, new RetryCmd() {
         
@@ -193,8 +198,8 @@ class ShardLeaderElectionContextBase extends ElectionContext {
             // The setData call used to get the parent version is also the trigger to
             // increment the version. We also do a sanity check that our leaderSeqPath exists.
 
-            ops.add(Op.check(leaderSeqPath, -1));
-            ops.add(Op.create(leaderPath, Utils.toJSON(leaderProps), zkClient.getZkACLProvider().getACLsToAdd(leaderPath), CreateMode.EPHEMERAL));
+            ops.add(Op.check(path, -1));
+            ops.add(Op.create(leaderPath, json, zkClient.getZkACLProvider().getACLsToAdd(leaderPath), CreateMode.EPHEMERAL));
             ops.add(Op.setData(parent, null, -1));
             List<OpResult> results;
 
@@ -721,9 +726,13 @@ final class OverseerElectionContext extends ElectionContext {
   @Override
   void runLeaderProcess(boolean weAreReplacement, int pauseBeforeStartMs) throws KeeperException,
       InterruptedException {
+    String path = leaderSeqPath.get();
+    if (path == null) {
+      // concurrently cancelled; just bail
+      return;
+    }
     log.info("I am going to be the leader {}", id);
-    final String id = leaderSeqPath
-        .substring(leaderSeqPath.lastIndexOf("/") + 1);
+    final String id = path.substring(path.lastIndexOf("/") + 1);
     ZkNodeProps myProps = new ZkNodeProps("id", id);
 
     zkClient.makePath(leaderPath, Utils.toJSON(myProps),

--- a/solr/core/src/java/org/apache/solr/cloud/ElectionContext.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ElectionContext.java
@@ -179,18 +179,18 @@ abstract class ShardLeaderElectionContextBase extends ElectionContext {
     ZkCmdExecutor zcmd = new ZkCmdExecutor(30000);
     zcmd.ensureExists(parent, zkClient);
     final byte[] json = Utils.toJSON(leaderProps);
-    final String path = leaderSeqPath.get();
-    if (path == null) {
-      // concurrently cancelled; just bail
-      return;
-    }
     try {
       RetryUtil.retryOnThrowable(NodeExistsException.class, 60000, 5000, new RetryCmd() {
         
         @Override
         public void execute() throws InterruptedException, KeeperException {
+          String path = leaderSeqPath.get();
+          if (path == null) {
+            // concurrently cancelled; just bail
+            return;
+          }
           synchronized (lock) {
-            log.info("Creating leader registration node {} after winning as {}", leaderPath, leaderSeqPath);
+            log.info("Creating leader registration node {} after winning as {}", leaderPath, path);
             List<Op> ops = new ArrayList<>(2);
 
             // We use a multi operation to get the parent nodes version, which will

--- a/solr/core/src/java/org/apache/solr/cloud/LeaderElector.java
+++ b/solr/core/src/java/org/apache/solr/cloud/LeaderElector.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -69,8 +70,6 @@ public  class LeaderElector {
 
   private volatile ElectionContext context;
 
-  private ElectionWatcher watcher;
-
   private Map<ContextKey,ElectionContext> electionContexts;
   private ContextKey contextKey;
 
@@ -106,9 +105,15 @@ public  class LeaderElector {
     List<String> seqs = zkClient.getChildren(holdElectionPath, null, true);
     sortSeqs(seqs);
 
-    String leaderSeqNodeName = context.leaderSeqPath.substring(context.leaderSeqPath.lastIndexOf('/') + 1);
+    String path = context.leaderSeqPath.get();
+    if (path == null) {
+      // context was concurrently cancelled; just bail
+      return;
+    }
+    String leaderSeqNodeName = path.substring(path.lastIndexOf('/') + 1);
     if (!seqs.contains(leaderSeqNodeName)) {
       log.warn("Our node is no longer in line to be leader");
+      retryElection(context, false);
       return;
     }
 
@@ -131,7 +136,26 @@ public  class LeaderElector {
     }
 
     if (leaderSeqNodeName.equals(seqs.get(0))) {
-      // I am the leader
+      // I am the leader - watch my node in case leadership is somehow revoked
+      try {
+        ElectionWatcher watcher = new ElectionWatcher(path, path, getSeq(path), context);
+        if (zkClient.exists(path, watcher, true) == null) {
+          // our node disappeared! try again
+          log.warn("Our node is no longer in line to be leader");
+          retryElection(context, false);
+          return;
+        }
+        log.info("Watching path {} to know if I lose leadership", context.leaderSeqPath);
+      } catch (KeeperException.SessionExpiredException e) {
+        throw e;
+      } catch (KeeperException e) {
+        // we couldn't set our watch for some other reason, retry
+        log.warn("Failed setting watch", e);
+        checkIfIamLeader(context, true);
+        return;
+      }
+
+      // Now we can run the leader process
       try {
         runIamLeaderProcess(context, replacement);
       } catch (KeeperException.NodeExistsException e) {
@@ -139,6 +163,7 @@ public  class LeaderElector {
         retryElection(context, false);
         return;
       }
+
     } else {
       // I am not the leader - watch the node below me
       String toWatch = seqs.get(0);
@@ -150,13 +175,14 @@ public  class LeaderElector {
       }
       try {
         String watchedNode = holdElectionPath + "/" + toWatch;
-        zkClient.getData(watchedNode, watcher = new ElectionWatcher(context.leaderSeqPath, watchedNode, getSeq(context.leaderSeqPath), context), null, true);
+        ElectionWatcher watcher = new ElectionWatcher(path, watchedNode, getSeq(path), context);
+        if (zkClient.exists(watchedNode, watcher, true) == null) {
+          // the previous node disappeared, check if we are the leader again
+          checkIfIamLeader(context, true);
+        }
         log.info("Watching path {} to know if I could be the leader", watchedNode);
       } catch (KeeperException.SessionExpiredException e) {
         throw e;
-      } catch (KeeperException.NoNodeException e) {
-        // the previous node disappeared, check if we are the leader again
-        checkIfIamLeader(context, true);
       } catch (KeeperException e) {
         // we couldn't set our watch for some other reason, retry
         log.warn("Failed setting watch", e);
@@ -261,7 +287,7 @@ public  class LeaderElector {
         }
 
         log.info("Joined leadership election with path: {}", leaderSeqPath);
-        context.leaderSeqPath = leaderSeqPath;
+        context.leaderSeqPath.set(leaderSeqPath);
         cont = false;
       } catch (ConnectionLossException e) {
         // we don't know if we made our node or not...
@@ -307,24 +333,17 @@ public  class LeaderElector {
     }
     checkIfIamLeader(context, replacement);
 
-    return getSeq(context.leaderSeqPath);
+    return getSeq(leaderSeqPath);
   }
 
   private class ElectionWatcher implements Watcher {
     final String myNode,watchedNode;
     final ElectionContext context;
 
-    private boolean canceled = false;
-
     private ElectionWatcher(String myNode, String watchedNode, int seq, ElectionContext context) {
       this.myNode = myNode;
       this.watchedNode = watchedNode;
       this.context = context;
-    }
-
-    void cancel() {
-      canceled = true;
-
     }
 
     @Override
@@ -333,7 +352,7 @@ public  class LeaderElector {
       if (EventType.None.equals(event.getType())) {
         return;
       }
-      if (canceled) {
+      if (!Objects.equals(context.leaderSeqPath.get(), myNode)) {
         log.info("This watcher is not active anymore {}", myNode);
         try {
           zkClient.delete(myNode, -1, true);
@@ -379,15 +398,12 @@ public  class LeaderElector {
   }
 
   void retryElection(ElectionContext context, boolean joinAtHead) throws KeeperException, InterruptedException, IOException {
-    ElectionWatcher watcher = this.watcher;
     ElectionContext ctx = context.copy();
     if (electionContexts != null) {
       electionContexts.put(contextKey, ctx);
     }
-    if (watcher != null) watcher.cancel();
     this.context.cancelElection();
     this.context = ctx;
     joinElection(ctx, true, joinAtHead);
   }
-
 }

--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -1819,7 +1819,7 @@ public class ZkController {
           return;
         }
         if (!path.endsWith(electionNode)) {
-          log.warn("Asked to rejoin with wrong election node : {}, current node is {}", electionNode, overseerElector.getContext().leaderSeqPath);
+          log.warn("Asked to rejoin with wrong election node : {}, current node is {}", electionNode, path);
           //however delete it . This is possible when the last attempt at deleting the election node failed.
           if (electionNode.startsWith(getNodeName())) {
             try {

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderElectionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderElectionTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -82,14 +83,21 @@ public class LeaderElectionTest extends SolrTestCaseJ4 {
     seqToThread = Collections.synchronizedMap(new HashMap<Integer,Thread>());
   }
   
-  class TestLeaderElectionContext extends ShardLeaderElectionContextBase {
-    private long runLeaderDelay = 0;
+  static class TestLeaderElectionContext extends ShardLeaderElectionContextBase {
+    private final ZkStateReader zkStateReader;
+    private final long runLeaderDelay;
 
     public TestLeaderElectionContext(LeaderElector leaderElector,
         String shardId, String collection, String coreNodeName, ZkNodeProps props,
         ZkStateReader zkStateReader, long runLeaderDelay) {
-      super (leaderElector, shardId, collection, coreNodeName, props, zkStateReader);
+      super(leaderElector, shardId, collection, coreNodeName, props, zkStateReader);
+      this.zkStateReader = zkStateReader;
       this.runLeaderDelay = runLeaderDelay;
+    }
+
+    @Override
+    public TestLeaderElectionContext copy() {
+      return new TestLeaderElectionContext(leaderElector, shardId, collection, id, leaderProps, zkStateReader, runLeaderDelay);
     }
 
     @Override
@@ -204,8 +212,8 @@ public class LeaderElectionTest extends SolrTestCaseJ4 {
     LeaderElector elector = new LeaderElector(zkClient);
     ZkNodeProps props = new ZkNodeProps(ZkStateReader.BASE_URL_PROP,
         "http://127.0.0.1/solr/", ZkStateReader.CORE_NAME_PROP, "");
-    ElectionContext context = new ShardLeaderElectionContextBase(elector,
-        "shard2", "collection1", "dummynode1", props, zkStateReader);
+    ElectionContext context = new TestLeaderElectionContext(elector,
+        "shard2", "collection1", "dummynode1", props, zkStateReader, 0);
     elector.setup(context);
     elector.joinElection(context, false);
     assertEquals("http://127.0.0.1/solr/",
@@ -215,28 +223,49 @@ public class LeaderElectionTest extends SolrTestCaseJ4 {
   @Test
   public void testCancelElection() throws Exception {
     LeaderElector first = new LeaderElector(zkClient);
+    LeaderElector second = new LeaderElector(zkClient);
+    setupTwoCandidates(first, second);
+
+    // cancel first allows second to become leader
+    first.getContext().cancelElection();
+    Thread.sleep(1000);
+    assertEquals("new leader was not registered", "http://127.0.0.1/solr/2/", getLeaderUrl("collection2", "slice1"));
+  }
+
+  @Test
+  public void testLeadershipRevoked() throws Exception {
+    LeaderElector first = new LeaderElector(zkClient);
+    LeaderElector second = new LeaderElector(zkClient);
+    setupTwoCandidates(first, second);
+
+    // delete the leader node
+    String path = first.getContext().leaderSeqPath;
+    zkClient.delete(path, -1, true);
+    Thread.sleep(1000);
+    assertEquals("new leader was not registered", "http://127.0.0.1/solr/2/", getLeaderUrl("collection2", "slice1"));
+    // also make sure that the leader noticed it was no longer leader and created a new candidate node
+    assertFalse("leader did not see its revocation", Objects.equals(path, first.getContext().leaderSeqPath));
+  }
+
+  private void setupTwoCandidates(LeaderElector first, LeaderElector second) throws Exception {
     ZkNodeProps props = new ZkNodeProps(ZkStateReader.BASE_URL_PROP,
         "http://127.0.0.1/solr/", ZkStateReader.CORE_NAME_PROP, "1");
-    ElectionContext firstContext = new ShardLeaderElectionContextBase(first,
-        "slice1", "collection2", "dummynode1", props, zkStateReader);
+    ElectionContext firstContext = new TestLeaderElectionContext(first,
+        "slice1", "collection2", "dummynode1", props, zkStateReader, 0);
     first.setup(firstContext);
     first.joinElection(firstContext, false);
 
     Thread.sleep(1000);
     assertEquals("original leader was not registered", "http://127.0.0.1/solr/1/", getLeaderUrl("collection2", "slice1"));
 
-    LeaderElector second = new LeaderElector(zkClient);
     props = new ZkNodeProps(ZkStateReader.BASE_URL_PROP,
         "http://127.0.0.1/solr/", ZkStateReader.CORE_NAME_PROP, "2");
-    ElectionContext context = new ShardLeaderElectionContextBase(second,
-        "slice1", "collection2", "dummynode2", props, zkStateReader);
+    ElectionContext context = new TestLeaderElectionContext(second,
+        "slice1", "collection2", "dummynode2", props, zkStateReader, 0);
     second.setup(context);
     second.joinElection(context, false);
     Thread.sleep(1000);
     assertEquals("original leader should have stayed leader", "http://127.0.0.1/solr/1/", getLeaderUrl("collection2", "slice1"));
-    firstContext.cancelElection();
-    Thread.sleep(1000);
-    assertEquals("new leader was not registered", "http://127.0.0.1/solr/2/", getLeaderUrl("collection2", "slice1"));
   }
 
   private String getLeaderUrl(final String collection, final String slice)

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderElectionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderElectionTest.java
@@ -239,7 +239,7 @@ public class LeaderElectionTest extends SolrTestCaseJ4 {
     setupTwoCandidates(first, second);
 
     // delete the leader node
-    String path = first.getContext().leaderSeqPath;
+    String path = first.getContext().leaderSeqPath.get();
     zkClient.delete(path, -1, true);
     Thread.sleep(1000);
     assertEquals("new leader was not registered", "http://127.0.0.1/solr/2/", getLeaderUrl("collection2", "slice1"));

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderElectionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderElectionTest.java
@@ -239,12 +239,17 @@ public class LeaderElectionTest extends SolrTestCaseJ4 {
     setupTwoCandidates(first, second);
 
     // delete the leader node
-    String path = first.getContext().leaderSeqPath.get();
+    ElectionContext ctx = first.getContext();
+    String path = ctx.leaderSeqPath.get();
     zkClient.delete(path, -1, true);
     Thread.sleep(1000);
     assertEquals("new leader was not registered", "http://127.0.0.1/solr/2/", getLeaderUrl("collection2", "slice1"));
     // also make sure that the leader noticed it was no longer leader and created a new candidate node
-    assertFalse("leader did not see its revocation", Objects.equals(path, first.getContext().leaderSeqPath));
+    ElectionContext newCtx = first.getContext();
+    assertNotSame("leader did not see its revocation", ctx, newCtx);
+    String newPath = newCtx.leaderSeqPath.get();
+    assertNotNull("leader did not create new candidate node", newPath);
+    assertFalse("leader did not create new candidate node?", Objects.equals(path, newPath));
   }
 
   private void setupTwoCandidates(LeaderElector first, LeaderElector second) throws Exception {

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
@@ -181,9 +181,9 @@ public class OverseerTest extends SolrTestCaseJ4 {
                 ZkStateReader.COLLECTION_PROP, collection,
                 ZkStateReader.CORE_NODE_NAME_PROP, coreNodeName);
             LeaderElector elector = new LeaderElector(zkClient);
-            ShardLeaderElectionContextBase ctx = new ShardLeaderElectionContextBase(
+            ShardLeaderElectionContextBase ctx = new LeaderElectionTest.TestLeaderElectionContext(
                 elector, shardId, collection, nodeName + "_" + coreName, props,
-                zkStateReader);
+                zkStateReader, 0);
             elector.setup(ctx);
             electionContext.put(coreName, ctx);
             elector.joinElection(ctx, false);


### PR DESCRIPTION
This stuff is really horrible. No real abstractions with lots of weird sharing of responsibility between `ZkController`, `LeaderElector`, and the actual `ElectionContext` instances :(

For now, I've just done a targeted change so that we can delete nodes in an election and the leader will notice if it loses leadership. I've just added one test but made sure the rest of the suite still passes. I went through the code quite a bit to try to understand the election flow and make sure this was safe.

I was mostly worried about weird edge cases where there could be concurrent calls to `LeaderElector.joinElection()` for the same elector, since I've added some calls to `retryElection` (which will in turn add new call paths from which `joinElection` can be called). But I think I've convinced myself that what's here is safe and correct. The poor abstractions/separation of responsibility makes it hard to safely serialize -- it would require `LeaderElector` and its `ElectionContext` to both share the same mutex (or better yet: re-write many of the flows so simple synchronization and/or thread confinement can be relied on...). So, without a mutex, I'm relying on the fact that it's a state machine, and I haven't added new transitions that will cause confusion/race conditions.

I hope to dig into a more substantial refactor of this ball of wax later.

I've based this pull request on the 5.5.3 head, assuming that we'd wait until we get a 5.5.3 upgrade in prod before trying to push this out.