### PR TITLE
support stats component as a plugin

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/DebugComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/DebugComponent.java
@@ -154,7 +154,7 @@ public class DebugComponent extends SearchComponent
   }
 
   @SuppressForbidden(reason = "Need currentTimeMillis, only used for naming")
-  private String generateRid(ResponseBuilder rb) {
+  public static String generateRid(ResponseBuilder rb) {
     String hostName = rb.req.getCore().getCoreDescriptor().getCoreContainer().getHostName();
     return hostName + "-" + rb.req.getCore().getName() + "-" + System.currentTimeMillis() + "-" + ridCounter.getAndIncrement();
   }

--- a/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
@@ -145,6 +145,10 @@ public class ResponseBuilder
     return -1;
   }
 
+  public boolean isDistrib() {
+    return isDistrib;
+  }
+
   public void addRequest(SearchComponent me, ShardRequest sreq) {
     outgoing.add(sreq);
     if ((sreq.purpose & ShardRequest.PURPOSE_PRIVATE) == 0) {


### PR DESCRIPTION
This just exposes a couple of small things to enable a search component that does a subset of debug stuff, deployed as a plugin (instead of having to include it as yet-another-patch to our lucene-solr fork).