### PR TITLE
Change GC metrics to be counters

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -56,10 +56,10 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
       String name = gcBean.getName().toLowerCase().replace(" ", "_");
       String cname = "collection_count_" + name;
       String ctime = "collection_time_" + name;
-      writePromDoc(writer, cname, gcBean.getName() + " collection count", "gauge");
+      writePromDoc(writer, cname, gcBean.getName() + " collection count", "counter");
       writer.printf("%s %d", cname, gcBean.getCollectionCount());
       writer.println();
-      writePromDoc(writer, ctime, gcBean.getName() + " collection time", "timer");
+      writePromDoc(writer, ctime, gcBean.getName() + " collection time", "counter");
       writer.printf("%s %d", ctime, gcBean.getCollectionTime());
       writer.println();
     }


### PR DESCRIPTION
Newer versions of prometheus actually care about the `# TYPE` comment and don't scrape targets with bad types.

The valid prometheus [metrics types](https://prometheus.io/docs/concepts/metric_types/) are:
* counter - can only go up
* gauge - can go up and down
* histogram and summary

This replaces the invalid `timer` type with a counter since it's total number of milliseconds and changes the count from a gauge to a counter. When possible, it's better to use counters since it tells prometheus "if you see this value go down, its a reset and not an actual negative value". E.g. if the samples are `[50, 100, 30]`, prometheus can infer that the metrics got reset and total count is actually 180