### PR TITLE
backport SOLR-13320 changes

### DIFF
--- a/solr/FULLSTORY-CHANGES.txt
+++ b/solr/FULLSTORY-CHANGES.txt
@@ -1,6 +1,6 @@
 ================= FullStory ================
 (Some of these changes are available in public Solr, if we update to the specified version )
-* fs.ignoreconflicts (Scott Blum)
+* fs.ignoreconflicts (Scott Blum) (Generally available from SOLR 8.2)
 * FullStory: special OOMKILLER handling for spaces (Scott Blum)
 * Remove pathological error reporting. Don't serialize the entire clusterstate to log (Generally available from SOLR 8.1)(Scott Blum)
 * Expose DocValuesTermsCollector and TermsQuery (Generally available from SOLR 8.1) (Jaime Yap) 

--- a/solr/FULLSTORY-CHANGES.txt
+++ b/solr/FULLSTORY-CHANGES.txt
@@ -1,6 +1,6 @@
 ================= FullStory ================
 (Some of these changes are available in public Solr, if we update to the specified version )
-* fs.ignoreconflicts (Scott Blum) (Generally available from SOLR 8.2)
+* SOLR-13320: add a param failOnVersionConflicts=false to updates not fail when there is a version conflict (Noble Paul, Scott Blum) (SOLR 8.2)
 * FullStory: special OOMKILLER handling for spaces (Scott Blum)
 * Remove pathological error reporting. Don't serialize the entire clusterstate to log (Generally available from SOLR 8.1)(Scott Blum)
 * Expose DocValuesTermsCollector and TermsQuery (Generally available from SOLR 8.1) (Jaime Yap) 

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
@@ -1126,9 +1126,6 @@ public class DistributedUpdateProcessor extends UpdateRequestProcessor {
                 if(cmd.getReq().getParams().getBool(CommonParams.FAIL_ON_VERSION_CONFLICTS, true) == false) {
                   return true;
                 }
-                if (cmd.getReq().getParams().getBool("fs.ignoreconflicts", false)) {
-                  return true;
-                }
                 throw new SolrException(ErrorCode.CONFLICT, "version conflict for " + cmd.getPrintableId()
                     + " expected=" + versionOnUpdate + " actual=" + foundVersion);
               }

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
@@ -1123,6 +1123,9 @@ public class DistributedUpdateProcessor extends UpdateRequestProcessor {
                 // we're ok if versions match, or if both are negative (all missing docs are equal), or if cmd
                 // specified it must exist (versionOnUpdate==1) and it does.
               } else {
+                if(cmd.getReq().getParams().getBool(CommonParams.FAIL_ON_VERSION_CONFLICTS, true) == false) {
+                  return true;
+                }
                 if (cmd.getReq().getParams().getBool("fs.ignoreconflicts", false)) {
                   return true;
                 }

--- a/solr/solrj/src/java/org/apache/solr/common/params/CommonParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/CommonParams.java
@@ -282,6 +282,8 @@ public interface CommonParams {
 
   String VERSION_FIELD="_version_";
 
+  String FAIL_ON_VERSION_CONFLICTS ="failOnVersionConflicts";
+
   String ID = "id";
   String JSON_MIME = "application/json";
 


### PR DESCRIPTION
ticket details .https://issues.apache.org/jira/browse/SOLR-13320

today we use the param `fs.ignoreConflicts=true` to avoid overwriting existing docs. A new feature is implemented in upstream which can achieve the same functionality  using the param `failOnVersionConflicts=false` . 