### PR TITLE
backporting SOLR-13468, SOLR-13484,SOLR-13493 from upstream

### DIFF
--- a/solr/FULLSTORY-CHANGES.txt
+++ b/solr/FULLSTORY-CHANGES.txt
@@ -5,3 +5,6 @@
 * Remove pathological error reporting. Don't serialize the entire clusterstate to log (Generally available from SOLR 8.1)(Scott Blum)
 * Expose DocValuesTermsCollector and TermsQuery (Generally available from SOLR 8.1) (Jaime Yap) 
 * LUCENE-8725: Make TermsQuery.SeekingTermSetTermsEnum a top level class and public (Generally available from SOLR 8.1)
+* SOLR-13468: autoscaling/suggestions should be able to give suggestions from config sent as a payload (Generally available from SOLR 8.2)(noble)
+* SOLR-13484: autoscaling/diagnostics API should be able to give diagnostics output from config sent as a payload (Generally available from SOLR 8.2) (noble)
+* SOLR-13493: /autoscaling/suggestions to be able to filter by type (Generally available from SOLR 8.2) (noble)

--- a/solr/core/src/java/org/apache/solr/cloud/autoscaling/AutoScalingHandler.java
+++ b/solr/core/src/java/org/apache/solr/cloud/autoscaling/AutoScalingHandler.java
@@ -29,8 +29,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -49,6 +51,7 @@ import org.apache.solr.common.MapWriter;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.AutoScalingParams;
 import org.apache.solr.common.params.CollectionAdminParams;
+import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.CommandOperation;
 import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.common.util.StrUtils;
@@ -102,6 +105,20 @@ public class AutoScalingHandler extends RequestHandlerBase implements Permission
     DEFAULT_ACTIONS.add(map);
   }
 
+  Optional<BiConsumer<SolrQueryResponse, AutoScalingConfig>> getSubpathExecutor(List<String> path, SolrQueryRequest request) {
+    if (path.size() == 3) {
+      if (DIAGNOSTICS.equals(path.get(2))) {
+        return Optional.of((rsp, autoScalingConf) -> handleDiagnostics(rsp, autoScalingConf));
+      } else if (SUGGESTIONS.equals(path.get(2))) {
+        return Optional.of((rsp, autoScalingConf) -> handleSuggestions(rsp, autoScalingConf, request.getParams()));
+      } else {
+        return Optional.empty();
+      }
+
+    }
+    return Optional.empty();
+  }
+
   @Override
   public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
     try {
@@ -111,8 +128,7 @@ public class AutoScalingHandler extends RequestHandlerBase implements Permission
       if ("GET".equals(httpMethod)) {
         String path = (String) req.getContext().get("path");
         if (path == null) path = "/cluster/autoscaling";
-        List<String> parts = StrUtils.splitSmart(path, '/');
-        if (parts.get(0).isEmpty()) parts.remove(0);
+        List<String> parts = StrUtils.splitSmart(path, '/', true);
 
         if (parts.size() < 2 || parts.size() > 3) {
           // invalid
@@ -120,7 +136,7 @@ public class AutoScalingHandler extends RequestHandlerBase implements Permission
         }
 
         AutoScalingConfig autoScalingConf = cloudManager.getDistribStateManager().getAutoScalingConfig();
-        if (parts.size() == 2)  {
+        if (parts.size() == 2) {
           autoScalingConf.writeMap(new MapWriter.EntryWriter() {
 
             @Override
@@ -129,16 +145,30 @@ public class AutoScalingHandler extends RequestHandlerBase implements Permission
               return this;
             }
           });
-        } else if (parts.size() == 3) {
-          if (DIAGNOSTICS.equals(parts.get(2))) {
-            handleDiagnostics(rsp, autoScalingConf);
-          } else if (SUGGESTIONS.equals(parts.get(2))) {
-            handleSuggestions(rsp, autoScalingConf);
-          }
+        } else {
+          getSubpathExecutor(parts, req).ifPresent(it -> it.accept(rsp, autoScalingConf));
         }
       } else {
         if (req.getContentStreams() == null) {
           throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "No commands specified for autoscaling");
+        }
+        String path = (String) req.getContext().get("path");
+        if (path != null) {
+          List<String> parts = StrUtils.splitSmart(path, '/', true);
+          if(parts.size() == 3){
+            getSubpathExecutor(parts, req).ifPresent(it -> {
+              Map map = null;
+              try {
+                map = (Map) Utils.fromJSON(req.getContentStreams().iterator().next().getStream());
+              } catch (IOException e1) {
+                throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "error parsing payload", e1);
+              }
+              it.accept(rsp, new AutoScalingConfig(map));
+            });
+
+            return;
+          }
+
         }
         List<CommandOperation> ops = CommandOperation.readCommands(req.getContentStreams(), rsp.getValues(), singletonCommands);
         if (ops == null) {
@@ -147,6 +177,7 @@ public class AutoScalingHandler extends RequestHandlerBase implements Permission
         }
         processOps(req, rsp, ops);
       }
+
     } catch (Exception e) {
       rsp.getValues().add("result", "failure");
       throw e;
@@ -156,9 +187,9 @@ public class AutoScalingHandler extends RequestHandlerBase implements Permission
   }
 
 
-  private void handleSuggestions(SolrQueryResponse rsp, AutoScalingConfig autoScalingConf) throws IOException {
+  private void handleSuggestions(SolrQueryResponse rsp, AutoScalingConfig autoScalingConf, SolrParams params) {
     rsp.getValues().add("suggestions",
-        PolicyHelper.getSuggestions(autoScalingConf, cloudManager));
+        PolicyHelper.getSuggestions(autoScalingConf, cloudManager, params));
   }
 
   public void processOps(SolrQueryRequest req, SolrQueryResponse rsp, List<CommandOperation> ops)
@@ -238,7 +269,7 @@ public class AutoScalingHandler extends RequestHandlerBase implements Permission
     return currentConfig.withProperties(configProps);
   }
 
-  private void handleDiagnostics(SolrQueryResponse rsp, AutoScalingConfig autoScalingConf) throws IOException {
+  private void handleDiagnostics(SolrQueryResponse rsp, AutoScalingConfig autoScalingConf) {
     Policy policy = autoScalingConf.getPolicy();
     rsp.getValues().add("diagnostics", PolicyHelper.getDiagnostics(policy, cloudManager));
   }
@@ -673,8 +704,11 @@ public class AutoScalingHandler extends RequestHandlerBase implements Permission
     switch (request.getHttpMethod()) {
       case "GET":
         return Name.AUTOSCALING_READ_PERM;
-      case "POST":
-        return Name.AUTOSCALING_WRITE_PERM;
+      case "POST": {
+        return StrUtils.splitSmart(request.getResource(), '/', true).size() == 3 ?
+            Name.AUTOSCALING_READ_PERM :
+            Name.AUTOSCALING_WRITE_PERM;
+      }
       default:
         return null;
     }

--- a/solr/core/src/test/org/apache/solr/cloud/CloudTestUtils.java
+++ b/solr/core/src/test/org/apache/solr/cloud/CloudTestUtils.java
@@ -187,7 +187,7 @@ public class CloudTestUtils {
       }
     };
   }
-  
+
   /**
    * Wait for a particular named trigger to be scheduled.
    * <p>
@@ -261,7 +261,7 @@ public class CloudTestUtils {
    * Helper class for sending (JSON) autoscaling requests that can randomize between V1 and V2 requests
    */
   public static class AutoScalingRequest extends SolrRequest {
-
+    private SolrParams params = null;
     /**
      * Creates a request using a randomized root path (V1 vs V2)
      *
@@ -280,6 +280,10 @@ public class CloudTestUtils {
      * @param message JSON payload, may be null
      */
     public static SolrRequest create(SolrRequest.METHOD m, String subPath, String message) {
+      return create(m,subPath,message,null);
+
+    }
+    public static SolrRequest create(SolrRequest.METHOD m, String subPath, String message, SolrParams params) {
       final boolean useV1 = LuceneTestCase.random().nextBoolean();
       String path = useV1 ? "/admin/autoscaling" : "/cluster/autoscaling";
       if (null != subPath) {
@@ -287,10 +291,11 @@ public class CloudTestUtils {
         path += subPath;
       }
       return useV1
-        ? new AutoScalingRequest(m, path, message)
-        : new V2Request.Builder(path).withMethod(m).withPayload(message).build();
+          ? new AutoScalingRequest(m, path, message).withParams(params)
+          : new V2Request.Builder(path).withMethod(m).withParams(params).withPayload(message).build();
+
     }
-    
+
     protected final String message;
 
     /**
@@ -304,9 +309,14 @@ public class CloudTestUtils {
       this.message = message;
     }
 
+
+    AutoScalingRequest withParams(SolrParams params){
+      this.params = params;
+      return this;
+    }
     @Override
     public SolrParams getParams() {
-      return null;
+      return params;
     }
 
     @Override

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/AutoScalingHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/AutoScalingHandlerTest.java
@@ -19,6 +19,8 @@ package org.apache.solr.cloud.autoscaling;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -35,8 +37,11 @@ import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.cloud.CloudTestUtils.AutoScalingRequest;
 import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.cloud.DocCollection;
+import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.ZkNodeProps;
 import org.apache.solr.common.params.AutoScalingParams;
+import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.TimeSource;
 import org.apache.solr.common.util.Utils;
@@ -48,6 +53,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.solr.client.solrj.cloud.autoscaling.Suggestion.Type.repair;
 import static org.apache.solr.common.cloud.ZkStateReader.SOLR_AUTOSCALING_CONF_PATH;
 import static org.apache.solr.common.util.Utils.getObjectByPath;
 
@@ -94,6 +100,60 @@ public class AutoScalingHandlerTest extends SolrCloudTestCase {
   public void beforeTest() throws Exception {
     // clear any persisted auto scaling configuration
     zkClient().setData(SOLR_AUTOSCALING_CONF_PATH, Utils.toJSON(new ZkNodeProps()), true);
+  }
+
+  public void testSuggestionsWithPayload() throws Exception {
+    CloudSolrClient solrClient = cluster.getSolrClient();
+    String COLLNAME = "testSuggestionsWithPayload.COLL";
+    CollectionAdminResponse adminResponse = CollectionAdminRequest.createCollection(COLLNAME, CONFIGSET_NAME, 1, 2)
+        .setMaxShardsPerNode(4)
+        .process(solrClient);
+    cluster.waitForActiveCollection(COLLNAME, 1, 2);
+    DocCollection collection = solrClient.getClusterStateProvider().getCollection(COLLNAME);
+    Replica aReplica = collection.getReplicas().get(0);
+
+    String configPayload = "{\n" +
+        "  'cluster-policy': [{'replica': 0, 'node': '_NODE'}]\n" +
+        "}";
+    configPayload = configPayload.replaceAll("_NODE", aReplica.getNodeName());
+    SolrRequest req = AutoScalingRequest.create(SolrRequest.METHOD.POST, "/suggestions", configPayload);
+    NamedList<Object> response = solrClient.request(req);
+    assertFalse(((Collection) response.get("suggestions")).isEmpty());
+    String replicaName = response._getStr("suggestions[0]/operation/command/move-replica/replica", null);
+    boolean[] passed = new boolean[]{false};
+    collection.forEachReplica((s, replica) -> {
+      if (replica.getName().equals(replicaName) && replica.getNodeName().equals(aReplica.getNodeName())) {
+        passed[0] = true;
+      }
+    });
+    assertTrue(passed[0]);
+
+    req = AutoScalingRequest.create(SolrRequest.METHOD.POST, "/suggestions", configPayload, new MapSolrParams(Collections.singletonMap("type", repair.name())));
+    response = solrClient.request(req);
+    assertTrue(((Collection) response.get("suggestions")).isEmpty());
+
+    CollectionAdminRequest.deleteCollection(COLLNAME)
+        .process(cluster.getSolrClient());
+  }
+  public void testDiagnosticsWithPayload() throws Exception {
+    CloudSolrClient solrClient = cluster.getSolrClient();
+    String COLLNAME = "testDiagnosticsWithPayload.COLL";
+    CollectionAdminResponse adminResponse = CollectionAdminRequest.createCollection(COLLNAME, CONFIGSET_NAME, 1, 2)
+        .setMaxShardsPerNode(4)
+        .process(solrClient);
+    cluster.waitForActiveCollection(COLLNAME, 1, 2);
+    DocCollection collection = solrClient.getClusterStateProvider().getCollection(COLLNAME);
+    Replica aReplica = collection.getReplicas().get(0);
+
+    String configPayload = "{\n" +
+        "  'cluster-policy': [{'replica': 0, 'node': '_NODE'}]\n" +
+        "}";
+    configPayload = configPayload.replaceAll("_NODE", aReplica.getNodeName());
+    SolrRequest req = AutoScalingRequest.create(SolrRequest.METHOD.POST, "/diagnostics", configPayload);
+    NamedList<Object> response = solrClient.request(req);
+    assertEquals(response._getStr("diagnostics/violations[0]/node",null),response._getStr("diagnostics/violations[0]/node",null));
+    CollectionAdminRequest.deleteCollection(COLLNAME)
+        .process(cluster.getSolrClient());
   }
 
   @Test
@@ -418,7 +478,7 @@ public class AutoScalingHandlerTest extends SolrCloudTestCase {
       solrClient.request(req);
       fail("expect exception");
     } catch (HttpSolrClient.RemoteExecutionException e) {
-      String message = String.valueOf(Utils.getObjectByPath(e.getMetaData(), true, "error/details[0]/errorMessages[0]"));
+      String message = String.valueOf(getObjectByPath(e.getMetaData(), true, "error/details[0]/errorMessages[0]"));
       assertTrue(message.contains("replica is required in"));
     }
 
@@ -560,7 +620,7 @@ public class AutoScalingHandlerTest extends SolrCloudTestCase {
       solrClient.request(req);
       fail("Adding a policy with 'cores' attribute should not have succeeded.");
     } catch (HttpSolrClient.RemoteExecutionException e)  {
-      String message = String.valueOf(Utils.getObjectByPath(e.getMetaData(), true, "error/details[0]/errorMessages[0]"));
+      String message = e.getMetaData()._getStr("error/details[0]/errorMessages[0]",null);
 
       // expected
       assertTrue(message.contains("cores is only allowed in 'cluster-policy'"));
@@ -731,7 +791,7 @@ public class AutoScalingHandlerTest extends SolrCloudTestCase {
     response = solrClient.request(req);
 
     Map<String, Object> diagnostics = (Map<String, Object>) response.get("diagnostics");
-    List sortedNodes = (List) Utils.getObjectByPath(response, false, "diagnostics/sortedNodes");
+    List sortedNodes = (List) response._get("diagnostics/sortedNodes", null);
     assertNotNull(sortedNodes);
 
     assertEquals(2, sortedNodes.size());
@@ -806,7 +866,7 @@ public class AutoScalingHandlerTest extends SolrCloudTestCase {
     log.info("started new jetty {}", runner1.getNodeName());
 
     response = waitForResponse(namedList -> {
-          List l = (List) Utils.getObjectByPath(namedList, false, "diagnostics/liveNodes");
+          List l = (List) namedList._get("diagnostics/liveNodes",null);
           if (l != null && l.contains(runner1.getNodeName())) return true;
           return false;
         },
@@ -822,13 +882,15 @@ public class AutoScalingHandlerTest extends SolrCloudTestCase {
     assertEquals(2, l.size());
     for (int i = 0; i < l.size(); i++) {
       Object suggestion = l.get(i);
-      assertEquals("violation", Utils.getObjectByPath(suggestion, true, "type"));
-      assertEquals("POST", Utils.getObjectByPath(suggestion, true, "operation/method"));
-      assertEquals("/c/readApiTestViolations", Utils.getObjectByPath(suggestion, true, "operation/path"));
-      String node = (String) Utils.getObjectByPath(suggestion, true, "operation/command/move-replica/targetNode");
+      assertEquals("violation", getObjectByPath(suggestion, true, "type"));
+      assertEquals("POST", getObjectByPath(suggestion, true, "operation/method"));
+      assertEquals("/c/readApiTestViolations", getObjectByPath(suggestion, true, "operation/path"));
+      String node = (String) getObjectByPath(suggestion, true, "operation/command/move-replica/targetNode");
       assertNotNull(node);
       assertEquals(runner1.getNodeName(), node);
     }
+    CollectionAdminRequest.deleteCollection("readApiTestViolations")
+        .process(cluster.getSolrClient());
   }
 
   @Test
@@ -997,15 +1059,15 @@ public class AutoScalingHandlerTest extends SolrCloudTestCase {
     solrClient.request(AutoScalingRequest.create(SolrRequest.METHOD.POST, setPropertiesCommand));
     SolrRequest req = AutoScalingRequest.create(SolrRequest.METHOD.GET, null);
     NamedList<Object> response = solrClient.request(req);
-    assertEquals("<4", Utils.getObjectByPath(response,false,"cluster-policy[0]/cores"));
-    assertEquals("#ANY", Utils.getObjectByPath(response,false,"cluster-policy[0]/node"));
+    assertEquals("<4", response._get("cluster-policy[0]/cores", null));
+    assertEquals("#ANY", response._get("cluster-policy[0]/node", null));
     setPropertiesCommand = "{'set-cluster-policy': [" +
         "{'cores': '<3','node': '#ANY'}]}";
     solrClient.request(AutoScalingRequest.create(SolrRequest.METHOD.POST, setPropertiesCommand));
     req = AutoScalingRequest.create(SolrRequest.METHOD.GET, null);
     response = solrClient.request(req);
-    assertEquals("<3", Utils.getObjectByPath(response,false,"cluster-policy[0]/cores"));
-    assertEquals("#ANY", Utils.getObjectByPath(response,false,"cluster-policy[0]/node"));
+    assertEquals("<3", response._get("cluster-policy[0]/cores", null));
+    assertEquals("#ANY", response._get("cluster-policy[0]/node", null));
 
   }
 }

--- a/solr/solr-ref-guide/src/solrcloud-autoscaling-api.adoc
+++ b/solr/solr-ref-guide/src/solrcloud-autoscaling-api.adoc
@@ -142,6 +142,128 @@ However, since the first node in the first example had more than 1 replica for a
 
 In the above example the node with port 8983 has two replicas for `shard1` in violation of our policy.
 
+=== Inline Policy Configuration
+
+If there is no autoscaling policy configured or if you wish to use a configuration other than the default, it is possible to send the autoscaling policy JSON as an inline payload as follows:
+
+[source,bash]
+----
+ curl -X POST -H 'Content-type:application/json'  -d '{
+ "cluster-policy": [
+   {"replica": 0,  "port" : "7574"}   ]
+ }' http://localhost:8983/api/cluster/autoscaling/diagnostics?omitHeader=true
+----
+
+*Output*
+[source,json]
+----
+{
+  "diagnostics":{
+    "sortedNodes":[{
+        "node":"10.0.0.80:7574_solr",
+        "isLive":true,
+        "cores":2.0,
+        "freedisk":567.4989128112793,
+        "port":7574,
+        "totaldisk":1044.122688293457,
+        "replicas":{"mycoll":{
+            "shard2":[{
+                "core_node7":{
+                  "core":"mycoll_shard2_replica_n4",
+                  "shard":"shard2",
+                  "collection":"mycoll",
+                  "node_name":"10.0.0.80:7574_solr",
+                  "type":"NRT",
+                  "base_url":"http://10.0.0.80:7574/solr",
+                  "state":"active",
+                  "force_set_state":"false",
+                  "INDEX.sizeInGB":6.426125764846802E-8}}],
+            "shard1":[{
+                "core_node3":{
+                  "core":"mycoll_shard1_replica_n1",
+                  "shard":"shard1",
+                  "collection":"mycoll",
+                  "node_name":"10.0.0.80:7574_solr",
+                  "type":"NRT",
+                  "base_url":"http://10.0.0.80:7574/solr",
+                  "state":"active",
+                  "force_set_state":"false",
+                  "INDEX.sizeInGB":6.426125764846802E-8}}]}}}
+      ,{
+        "node":"10.0.0.80:8983_solr",
+        "isLive":true,
+        "cores":2.0,
+        "freedisk":567.498908996582,
+        "port":8983,
+        "totaldisk":1044.122688293457,
+        "replicas":{"mycoll":{
+            "shard2":[{
+                "core_node8":{
+                  "core":"mycoll_shard2_replica_n6",
+                  "shard":"shard2",
+                  "collection":"mycoll",
+                  "node_name":"10.0.0.80:8983_solr",
+                  "type":"NRT",
+                  "leader":"true",
+                  "base_url":"http://10.0.0.80:8983/solr",
+                  "state":"active",
+                  "force_set_state":"false",
+                  "INDEX.sizeInGB":6.426125764846802E-8}}],
+            "shard1":[{
+                "core_node5":{
+                  "core":"mycoll_shard1_replica_n2",
+                  "shard":"shard1",
+                  "collection":"mycoll",
+                  "node_name":"10.0.0.80:8983_solr",
+                  "type":"NRT",
+                  "leader":"true",
+                  "base_url":"http://10.0.0.80:8983/solr",
+                  "state":"active",
+                  "force_set_state":"false",
+                  "INDEX.sizeInGB":6.426125764846802E-8}}]}}}],
+    "liveNodes":["10.0.0.80:7574_solr",
+      "10.0.0.80:8983_solr"],
+    "violations":[{
+        "collection":"mycoll",
+        "tagKey":7574,
+        "violation":{
+          "replica":{
+            "NRT":2,
+            "count":2},
+          "delta":2.0},
+        "clause":{
+          "replica":0,
+          "port":"7574",
+          "collection":"mycoll"},
+        "violatingReplicas":[{
+            "core_node7":{
+              "core":"mycoll_shard2_replica_n4",
+              "shard":"shard2",
+              "collection":"mycoll",
+              "node_name":"10.0.0.80:7574_solr",
+              "type":"NRT",
+              "base_url":"http://10.0.0.80:7574/solr",
+              "state":"active",
+              "force_set_state":"false",
+              "INDEX.sizeInGB":6.426125764846802E-8}}
+          ,{
+            "core_node3":{
+              "core":"mycoll_shard1_replica_n1",
+              "shard":"shard1",
+              "collection":"mycoll",
+              "node_name":"10.0.0.80:7574_solr",
+              "type":"NRT",
+              "base_url":"http://10.0.0.80:7574/solr",
+              "state":"active",
+              "force_set_state":"false",
+              "INDEX.sizeInGB":6.426125764846802E-8}}]}],
+    "config":{
+      "cluster-policy":[{
+          "replica":0,
+          "port":"7574"}]}},
+  "WARNING":"This response format is experimental.  It is likely to change in the future."}
+----
+
 == Suggestions API
 Suggestions are operations recommended by the system according to the policies and preferences the user has set.
 
@@ -195,6 +317,76 @@ The API is available at `/admin/autoscaling/suggestions`. Here is an example out
 ----
 
 The suggested `operation` is an API call that can be invoked to remedy the current violation.
+
+The types of suggestions available are
+
+* `violation` : Fixes a violation to one or more policy rules
+* `repair` : Add missing replicas
+* `improvement` : move replicas around so that the load is more evenly balanced according to the autoscaling preferences
+
+By default, the suggestions API return all of the above , in that order. However it is possible to fetch only certain types by adding a request parameter `type`. e.g: `type=violation&type=repair`
+
+=== Inline Policy Configuration
+
+If there is no autoscaling policy configured or if you wish to use a configuration other than the default, it is possible to send the autoscaling policy JSON as an inline payload as follows:
+
+[source,bash]
+----
+curl -X POST -H 'Content-type:application/json'  -d '{
+ "cluster-policy": [
+   {"replica": 0,  "port" : "7574"}
+   ]
+}' http://localhost:8983/solr/admin/autoscaling/suggestions?omitHeader=true
+----
+
+*Output*
+[source,json]
+----
+{
+  "suggestions":[{
+      "type":"violation",
+      "violation":{
+        "collection":"mycoll",
+        "tagKey":7574,
+        "violation":{
+          "replica":{
+            "NRT":2,
+            "count":2},
+          "delta":2.0},
+        "clause":{
+          "replica":0,
+          "port":"7574",
+          "collection":"mycoll"}},
+      "operation":{
+        "method":"POST",
+        "path":"/c/mycoll",
+        "command":{"move-replica":{
+            "targetNode":"10.0.0.80:8983_solr",
+            "inPlaceMove":"true",
+            "replica":"core_node8"}}}},
+    {
+      "type":"violation",
+      "violation":{
+        "collection":"mycoll",
+        "tagKey":7574,
+        "violation":{
+          "replica":{
+            "NRT":2,
+            "count":2},
+          "delta":2.0},
+        "clause":{
+          "replica":0,
+          "port":"7574",
+          "collection":"mycoll"}},
+      "operation":{
+        "method":"POST",
+        "path":"/c/mycoll",
+        "command":{"move-replica":{
+            "targetNode":"10.0.0.80:8983_solr",
+            "inPlaceMove":"true",
+            "replica":"core_node5"}}}}],
+  "WARNING":"This response format is experimental.  It is likely to change in the future."}
+----
 
 == History API
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/PolicyHelper.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/PolicyHelper.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -46,6 +47,7 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.ReplicaPosition;
+import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.Pair;
 import org.apache.solr.common.util.TimeSource;
 import org.apache.solr.common.util.Utils;
@@ -55,6 +57,10 @@ import org.slf4j.LoggerFactory;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.solr.client.solrj.cloud.autoscaling.Suggestion.Type.improvement;
+import static org.apache.solr.client.solrj.cloud.autoscaling.Suggestion.Type.repair;
+import static org.apache.solr.client.solrj.cloud.autoscaling.Suggestion.Type.unresolved_violation;
+import static org.apache.solr.client.solrj.cloud.autoscaling.Suggestion.Type.violation;
 import static org.apache.solr.client.solrj.cloud.autoscaling.Variable.Type.FREEDISK;
 import static org.apache.solr.common.ConditionalMapWriter.dedupeKeyPredicate;
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.ADDREPLICA;
@@ -229,46 +235,60 @@ public class PolicyHelper {
       }
     });
   }
-
   public static List<Suggester.SuggestionInfo> getSuggestions(AutoScalingConfig autoScalingConf,
-                                                              SolrCloudManager cloudManager) {
-    return getSuggestions(autoScalingConf, cloudManager, 20, 10);
+                                                              SolrCloudManager cloudManager, SolrParams params) {
+    return getSuggestions(autoScalingConf, cloudManager, 20, 10, params);
   }
 
   public static List<Suggester.SuggestionInfo> getSuggestions(AutoScalingConfig autoScalingConf,
-                                                              SolrCloudManager cloudManager, int max, int timeoutInSecs) {
+                                                              SolrCloudManager cloudManager) {
+    return getSuggestions(autoScalingConf, cloudManager, 20, 10, null);
+  }
+
+
+  public static List<Suggester.SuggestionInfo> getSuggestions(AutoScalingConfig autoScalingConf,
+                                                              SolrCloudManager cloudManager, int max, int timeoutInSecs, SolrParams params) {
     Policy policy = autoScalingConf.getPolicy();
     Suggestion.Ctx ctx = new Suggestion.Ctx();
     ctx.endTime = cloudManager.getTimeSource().getTimeNs() + TimeUnit.SECONDS.toNanos(timeoutInSecs);
     ctx.max = max;
     ctx.session = policy.createSession(cloudManager);
-    List<Violation> violations = ctx.session.getViolations();
-    for (Violation violation : violations) {
-      violation.getClause().getThirdTag().varType.getSuggestions(ctx.setViolation(violation));
-      ctx.violation = null;
-    }
+    String[] t = params == null ? null : params.getParams("type");
+    List<String> types = t == null? Collections.EMPTY_LIST: Arrays.asList(t);
 
-    for (Violation current : ctx.session.getViolations()) {
-      for (Violation old : violations) {
-        if (!ctx.needMore()) return ctx.getSuggestions();
-        if (current.equals(old)) {
-          //could not be resolved
-          ctx.suggestions.add(new Suggester.SuggestionInfo(current, null, "unresolved-violation"));
-          break;
+    if(types.isEmpty() || types.contains(violation.name())) {
+      List<Violation> violations = ctx.session.getViolations();
+      for (Violation violation : violations) {
+        violation.getClause().getThirdTag().varType.getSuggestions(ctx.setViolation(violation));
+        ctx.violation = null;
+      }
+
+      for (Violation current : ctx.session.getViolations()) {
+        for (Violation old : violations) {
+          if (!ctx.needMore()) return ctx.getSuggestions();
+          if (current.equals(old)) {
+            //could not be resolved
+            ctx.suggestions.add(new Suggester.SuggestionInfo(current, null, unresolved_violation));
+            break;
+          }
         }
       }
     }
 
-    if (ctx.needMore()) {
-      try {
-        addMissingReplicas(cloudManager, ctx);
-      } catch (IOException e) {
-        log.error("Unable to fetch cluster state", e);
+    if(types.isEmpty() || types.contains(repair.name())) {
+      if (ctx.needMore()) {
+        try {
+          addMissingReplicas(cloudManager, ctx);
+        } catch (IOException e) {
+          log.error("Unable to fetch cluster state", e);
+        }
       }
     }
 
-    if (ctx.needMore()) {
-      suggestOptimizations(ctx, Math.min(ctx.max - ctx.getSuggestions().size(), 10));
+    if(types.isEmpty() || types.contains(improvement.name())) {
+      if (ctx.needMore()) {
+        suggestOptimizations(ctx, Math.min(ctx.max - ctx.getSuggestions().size(), 10));
+      }
     }
     return ctx.getSuggestions();
   }
@@ -297,7 +317,7 @@ public class PolicyHelper {
       SolrRequest suggestion = ctx.addSuggestion(
           ctx.session.getSuggester(ADDREPLICA)
               .hint(Hint.REPLICATYPE, type)
-              .hint(Hint.COLL_SHARD, new Pair(coll.getName(), shard)), "repair");
+              .hint(Hint.COLL_SHARD, new Pair(coll.getName(), shard)), Suggestion.Type.repair);
       if (suggestion == null) return;
       delta++;
     }
@@ -323,7 +343,7 @@ public class PolicyHelper {
           Suggester suggester = ctx.session.getSuggester(MOVEREPLICA)
               .hint(Hint.COLL_SHARD, new Pair<>(e.getKey(), shard))
               .hint(Hint.SRC_NODE, row.node);
-          ctx.addSuggestion(suggester, "improvement");
+          ctx.addSuggestion(suggester, Suggestion.Type.improvement);
           if (ctx.getSuggestions().size() >= maxTotalSuggestions) break;
         }
       }
@@ -504,6 +524,7 @@ public class PolicyHelper {
     return wrapper;
 
   }
+
 
   static ThreadLocal<SessionWrapper> SESSION_WRAPPPER_REF = new ThreadLocal<>();
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Suggester.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Suggester.java
@@ -224,11 +224,11 @@ public abstract class Suggester implements MapWriter {
   }
 
   public static class SuggestionInfo implements MapWriter {
-    String type;
+    Suggestion.Type type;
     Violation violation;
     SolrRequest operation;
 
-    public SuggestionInfo(Violation violation, SolrRequest op, String type) {
+    public SuggestionInfo(Violation violation, SolrRequest op, Suggestion.Type type) {
       this.violation = violation;
       this.operation = op;
       this.type = type;
@@ -244,7 +244,7 @@ public abstract class Suggester implements MapWriter {
 
     @Override
     public void writeMap(EntryWriter ew) throws IOException {
-      ew.put("type", type);
+      ew.put("type", type.name());
       if(violation!= null) ew.put("violation",
           new ConditionalMapWriter(violation,
               (k, v) -> !"violatingReplicas".equals(k)));

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Suggestion.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Suggestion.java
@@ -31,6 +31,11 @@ import org.apache.solr.common.util.Pair;
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.MOVEREPLICA;
 
 public class Suggestion {
+
+  public enum Type {
+    violation, repair, improvement, unresolved_violation;
+  }
+
   static class Ctx {
     long endTime = -1;
     int max = Integer.MAX_VALUE;
@@ -38,10 +43,10 @@ public class Suggestion {
     public Violation violation;
     List<Suggester.SuggestionInfo> suggestions = new ArrayList<>();
     SolrRequest addSuggestion(Suggester suggester) {
-      return addSuggestion(suggester, "violation");
+      return addSuggestion(suggester, Type.violation);
     }
 
-    SolrRequest addSuggestion(Suggester suggester, String type) {
+    SolrRequest addSuggestion(Suggester suggester, Type type) {
       SolrRequest op = suggester.getSuggestion();
       if (op != null) {
         session = suggester.getSession();

--- a/solr/solrj/src/java/org/apache/solr/common/util/StrUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/StrUtils.java
@@ -39,6 +39,15 @@ public class StrUtils {
     return lst;
 
   }
+
+  public static List<String> splitSmart(String s, char separator, boolean trimEmpty) {
+    List<String> l = splitSmart(s, separator);
+    if(trimEmpty){
+      if (l.size() > 0 && l.get(0).isEmpty()) l.remove(0);
+    }
+    return l;
+  }
+
   /**
    * Split a string based on a separator, but don't split if it's inside
    * a string.  Assume '\' escapes the next char both inside and

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy2.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy2.java
@@ -426,20 +426,20 @@ public class TestPolicy2 extends SolrTestCaseJ4 {
     List<Suggester.SuggestionInfo> suggestions = PolicyHelper.getSuggestions(new AutoScalingConfig((Map<String, Object>) getObjectByPath(m, false, "diagnostics/config"))
         , cloudManagerFromDiagnostics);
     for (Suggester.SuggestionInfo suggestion : suggestions) {
-      assertEquals("unresolved-violation", suggestion._get("type", null));
+      assertEquals("unresolved_violation", suggestion._get("type", null));
       assertEquals("1.0", suggestion._getStr("violation/violation/delta", null));
     }
   }
 
 
-  @Ignore
+  @Ignore("This takes too long to run. enable it for perf testing")
   public void testInfiniteLoop() {
     Row.cacheStats.clear();
     Map<String, Object> m = (Map<String, Object>) loadFromResource("testInfiniteLoop.json");
     SolrCloudManager cloudManagerFromDiagnostics = createCloudManagerFromDiagnostics(m);
     List<Suggester.SuggestionInfo> suggestions = PolicyHelper.getSuggestions(
         new AutoScalingConfig((Map<String, Object>) getObjectByPath(m, false, "diagnostics/config"))
-        , cloudManagerFromDiagnostics, 200, 1200);
+        , cloudManagerFromDiagnostics, 200, 1200, null);
 
     System.out.println(suggestions);
   }


### PR DESCRIPTION
Backporting the following tickets from upstream. 

* SOLR-13468: autoscaling/suggestions should be able to give suggestions from config sent as a payload (Generally available from SOLR 8.2)(noble)
https://issues.apache.org/jira/browse/SOLR-13468
* SOLR-13484: autoscaling/diagnostics API should be able to give diagnostics output from config sent as a payload (Generally available from SOLR 8.2) (noble)
https://issues.apache.org/jira/browse/SOLR-13484
* SOLR-13493: /autoscaling/suggestions to be able to filter by type (Generally available from SOLR 8.2) (noble)
https://issues.apache.org/jira/browse/SOLR-13493