### PR TITLE
backport  SOLR-13504, SOLR-13329

### DIFF
--- a/solr/FULLSTORY-CHANGES.txt
+++ b/solr/FULLSTORY-CHANGES.txt
@@ -8,3 +8,7 @@
 * SOLR-13468: autoscaling/suggestions should be able to give suggestions from config sent as a payload (Generally available from SOLR 8.2)(noble)
 * SOLR-13484: autoscaling/diagnostics API should be able to give diagnostics output from config sent as a payload (Generally available from SOLR 8.2) (noble)
 * SOLR-13493: /autoscaling/suggestions to be able to filter by type (Generally available from SOLR 8.2) (noble)
+* SOLR-13504: In autoscaling policies, use an explicit 'nodeset' attribute for filtering
+  nodes instead of using them directly at the toplevel (Generally available from SOLR 8.2)(noble)
+* SOLR-13504: In autoscaling policies, use an explicit 'put : on-each'
+  to specify the the rules is applied on each node (Generally available from SOLR 8.2)(noble)

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/AutoScalingHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/AutoScalingHandlerTest.java
@@ -714,6 +714,22 @@ public class AutoScalingHandlerTest extends SolrCloudTestCase {
     List clusterPolicy = (List) loaded.get("cluster-policy");
     assertNotNull(clusterPolicy);
     assertEquals(3, clusterPolicy.size());
+
+    setClusterPolicyCommand = "{" +
+        " 'set-cluster-policy': [" +
+        "      {'cores':'<10', 'node':'#ANY'}," +
+        "      {'replica':'<2', 'shard': '#EACH', 'node': '#ANY'}," +
+        "      {'replica':0, put : on-each, nodeset:{'nodeRole':'overseer'} }" +
+        "    ]" +
+        "}";
+    req = AutoScalingRequest.create(SolrRequest.METHOD.POST, setClusterPolicyCommand);
+    response = solrClient.request(req);
+    assertEquals(response.get("result").toString(), "success");
+    data = zkClient().getData(SOLR_AUTOSCALING_CONF_PATH, null, null, true);
+    loaded = ZkNodeProps.load(data);
+    clusterPolicy = (List) loaded.get("cluster-policy");
+    assertNotNull(clusterPolicy);
+    assertEquals(3, clusterPolicy.size());
   }
 
   @Test

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Clause.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Clause.java
@@ -57,13 +57,13 @@ import static org.apache.solr.common.util.Utils.toJSONString;
  */
 public class Clause implements MapWriter, Comparable<Clause> {
   public static final String NODESET = "nodeset";
-  private static final Set<String> IGNORE_TAGS = new HashSet<>(Arrays.asList(REPLICA, COLLECTION, SHARD, "strict", "type", "put", NODESET));
+  static final Set<String> IGNORE_TAGS = new HashSet<>(Arrays.asList(REPLICA, COLLECTION, SHARD, "strict", "type", "put", NODESET));
 
   private final int hashCode;
   final boolean hasComputedValue;
   final Map<String, Object> original;
   final Clause derivedFrom;
-  private boolean nodeSetPresent = false;
+  boolean nodeSetPresent = false;
   Condition collection, shard, replica, tag, globalTag;
   final Replica.Type type;
   boolean strict;
@@ -568,10 +568,6 @@ public class Clause implements MapWriter, Comparable<Clause> {
 
   public List<Violation> test(Policy.Session session, double[] deviations) {
     if (isPerCollectiontag()) {
-      if(nodeSetPresent) {
-
-      }
-
       return tag.varType == Type.NODE ||
           (tag.varType.meta.isNodeSpecificVal() && replica.computedType == null) ?
           testPerNode(session, deviations) :

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Clause.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Clause.java
@@ -66,12 +66,14 @@ public class Clause implements MapWriter, Comparable<Clause> {
   boolean nodeSetPresent = false;
   Condition collection, shard, replica, tag, globalTag;
   final Replica.Type type;
+  Put put;
   boolean strict;
 
   protected Clause(Clause clause, Function<Condition, Object> computedValueEvaluator) {
     this.original = clause.original;
     this.hashCode = original.hashCode();
     this.type = clause.type;
+    this.put = clause.put;
     this.nodeSetPresent = clause.nodeSetPresent;
     this.collection = clause.collection;
     this.shard = clause.shard;
@@ -84,7 +86,7 @@ public class Clause implements MapWriter, Comparable<Clause> {
   }
 
   // internal use only
-  Clause(Map<String, Object> original, Condition tag, Condition globalTag, boolean isStrict,  boolean nodeSetPresent) {
+  Clause(Map<String, Object> original, Condition tag, Condition globalTag, boolean isStrict, Put put, boolean nodeSetPresent) {
     this.hashCode = original.hashCode();
     this.original = original;
     this.tag = tag;
@@ -94,6 +96,7 @@ public class Clause implements MapWriter, Comparable<Clause> {
     this.hasComputedValue = false;
     this.strict = isStrict;
     derivedFrom = null;
+    this.put = put;
     this.nodeSetPresent = nodeSetPresent;
   }
 
@@ -103,6 +106,12 @@ public class Clause implements MapWriter, Comparable<Clause> {
     this.hashCode = original.hashCode();
     String type = (String) m.get("type");
     this.type = type == null || ANY.equals(type) ? null : Replica.Type.valueOf(type.toUpperCase(Locale.ROOT));
+    String put = (String) m.getOrDefault("put", m.containsKey(NODESET)? Put.ON_ALL.val: null );
+    if (put != null) {
+      this.put = Put.get(put);
+      if (this.put == null) throwExp(m, "invalid value for put : {0}", put);
+    }
+
     strict = Boolean.parseBoolean(String.valueOf(m.getOrDefault("strict", "true")));
     Optional<String> globalTagName = m.keySet().stream().filter(Policy.GLOBAL_ONLY_TAGS::contains).findFirst();
     if (globalTagName.isPresent()) {
@@ -348,7 +357,7 @@ public class Clause implements MapWriter, Comparable<Clause> {
     } catch (IllegalArgumentException iae) {
       throw iae;
     } catch (Exception e) {
-      throwExp(m, "Invalid tag : {0} ", s);
+      throwExp(m, " Invalid tag : {0} "+ e.getMessage(), s);
       return null;
     }
   }
@@ -400,26 +409,25 @@ public class Clause implements MapWriter, Comparable<Clause> {
     return operand;
   }
 
+
+  private boolean isRowPass(ComputedValueEvaluator eval, Object t, Row row) {
+    eval.node = row.node;
+    if (t instanceof Condition) {
+      Condition tag = (Condition) t;
+      if (tag.computedType != null) tag = evaluateValue(tag, eval);
+      return tag.isPass(row);
+    } else {
+      return t.equals(row.getVal(tag.name));
+    }
+  }
+
   List<Violation> testGroupNodes(Policy.Session session, double[] deviations) {
     //e.g:  {replica:'#EQUAL', shard:'#EACH',  sysprop.zone:'#EACH'}
     ComputedValueEvaluator eval = new ComputedValueEvaluator(session);
     eval.collName = (String) collection.getValue();
     Violation.Ctx ctx = new Violation.Ctx(this, session.matrix, eval);
 
-    Set tags = new HashSet();
-    for (Row row : session.matrix) {
-      eval.node = row.node;
-      Condition tag = this.tag;
-      if (tag.computedType != null) tag = evaluateValue(tag, eval);
-      Object val = row.getVal(tag.name);
-      if (val != null) {
-        if (tag.op == LESS_THAN || tag.op == GREATER_THAN) {
-          tags.add(this.tag);
-        } else if (tag.isPass(val)) {
-          tags.add(val);
-        }
-      }
-    }
+    Set tags = getUniqueTags(session, eval);
     if (tags.isEmpty()) return Collections.emptyList();
 
     Set<String> shards = getShardNames(session, eval);
@@ -428,17 +436,10 @@ public class Clause implements MapWriter, Comparable<Clause> {
       final ReplicaCount replicaCount = new ReplicaCount();
       eval.shardName = s;
 
-      for (Object t : tags) {
+      for (Object tag : tags) {
         replicaCount.reset();
         for (Row row : session.matrix) {
-          eval.node = row.node;
-          if (t instanceof Condition) {
-            Condition tag = (Condition) t;
-            if (tag.computedType != null) tag = evaluateValue(tag, eval);
-            if (!tag.isPass(row)) continue;
-          } else {
-            if (!t.equals(row.getVal(tag.name))) continue;
-          }
+         if(!isRowPass(eval, tag, row)) continue;
           addReplicaCountsForNode(eval, replicaCount, row);
         }
 
@@ -451,27 +452,57 @@ public class Clause implements MapWriter, Comparable<Clause> {
               null,
               replicaCountCopy,
               sealedClause.getReplica().replicaCountDelta(replicaCountCopy),
-              t);
-          ctx.resetAndAddViolation(t, replicaCountCopy, violation);
-          sealedClause.addViolatingReplicas(sealedClause.tag, eval, ctx, tag.name, t, violation, session);
+              tag);
+          ctx.resetAndAddViolation(tag, replicaCountCopy, violation);
+          sealedClause.addViolatingReplicasForGroup(sealedClause.tag, eval, ctx, this.tag.name, tag, violation, session.matrix);
           if (!this.strict && deviations != null) {
-            tag.varType.computeDeviation(session, deviations, replicaCount, sealedClause);
+            this.tag.varType.computeDeviation(session, deviations, replicaCount, sealedClause);
           }
         } else {
-          if (replica.op == RANGE_EQUAL) tag.varType.computeDeviation(session, deviations, replicaCount, sealedClause);
+          if (replica.op == RANGE_EQUAL) this.tag.varType.computeDeviation(session, deviations, replicaCount, sealedClause);
         }
       }
     }
     return ctx.allViolations;
   }
 
-  void addViolatingReplicas(Condition tag,
-                            ComputedValueEvaluator eval,
-                            Violation.Ctx ctx, String tagName, Object tagVal,
-                            Violation violation,
-                            Policy.Session session) {
+  private Set getUniqueTags(Policy.Session session, ComputedValueEvaluator eval) {
+    Set tags =  new HashSet();
+    if(tag.op == WILDCARD){
+      for (Row row : session.matrix) {
+        eval.node = row.node;
+        Condition tag = this.tag;
+        if (tag.computedType != null) tag = evaluateValue(tag, eval);
+        Object val = row.getVal(tag.name);
+        if (val != null) {
+          if (tag.op == LESS_THAN || tag.op == GREATER_THAN) {
+            tags.add(this.tag);
+          } else if (tag.isPass(val)) {
+            tags.add(val);
+          }
+        }
+      }
+
+    } else {
+
+      if (tag.op == LESS_THAN || tag.op == GREATER_THAN || tag.op == RANGE_EQUAL || tag.op == NOT_EQUAL) {
+        tags.add(tag); // eg: freedisk > 100
+      } else if (tag.val instanceof Collection) {
+        tags.addAll((Collection) tag.val); //e: sysprop.zone:[east,west]
+      } else {
+        tags.add(tag.val);//
+      }
+    }
+    return tags;
+  }
+
+  void addViolatingReplicasForGroup(Condition tag,
+                                    ComputedValueEvaluator eval,
+                                    Violation.Ctx ctx, String tagName, Object tagVal,
+                                    Violation violation,
+                                    List<Row> nodes) {
     if (tag.varType.addViolatingReplicas(ctx)) return;
-    for (Row row : session.matrix) {
+    for (Row row : nodes) {
       if (tagVal.equals(row.getVal(tagName))) {
         row.forEachReplica(eval.collName, ri -> {
           if (Policy.ANY.equals(eval.shardName)
@@ -535,7 +566,8 @@ public class Clause implements MapWriter, Comparable<Clause> {
               sealedClause.getReplica().replicaCountDelta(replicaCountCopy),
               eval.node);
           ctx.resetAndAddViolation(row.node, replicaCountCopy, violation);
-          sealedClause.addViolatingReplicas(sealedClause.tag, eval, ctx, NODE, row.node, violation, session);
+          sealedClause.addViolatingReplicasForGroup(sealedClause.tag, eval, ctx, NODE, row.node, violation,
+              Collections.singletonList(row));
           if (!this.strict && deviations != null) {
             tag.varType.computeDeviation(session, deviations, replicaCount, sealedClause);
           }
@@ -568,6 +600,14 @@ public class Clause implements MapWriter, Comparable<Clause> {
 
   public List<Violation> test(Policy.Session session, double[] deviations) {
     if (isPerCollectiontag()) {
+      if(nodeSetPresent) {
+        if(put == Put.ON_EACH){
+          return testPerNode(session, deviations) ;
+        } else {
+          return testGroupNodes(session, deviations);
+        }
+      }
+
       return tag.varType == Type.NODE ||
           (tag.varType.meta.isNodeSpecificVal() && replica.computedType == null) ?
           testPerNode(session, deviations) :
@@ -581,7 +621,7 @@ public class Clause implements MapWriter, Comparable<Clause> {
         if (!sealedClause.getGlobalTag().isPass(r)) {
           ctx.resetAndAddViolation(r.node, null, new Violation(sealedClause, null, null, r.node, r.getVal(sealedClause.globalTag.name),
               sealedClause.globalTag.delta(r.getVal(globalTag.name)), r.node));
-          addViolatingReplicas(sealedClause.globalTag, computedValueEvaluator, ctx, Type.CORES.tagName, r.node, ctx.currentViolation, session);
+          addViolatingReplicasForGroup(sealedClause.globalTag, computedValueEvaluator, ctx, Type.CORES.tagName, r.node, ctx.currentViolation, session.matrix);
 
         }
       }
@@ -709,5 +749,22 @@ public class Clause implements MapWriter, Comparable<Clause> {
   }
 
   public static final String METRICS_PREFIX = "metrics:";
+
+  enum Put {
+    ON_ALL("on-all"), ON_EACH("on-each");
+
+    public final String val;
+
+    Put(String s) {
+      this.val = s;
+    }
+
+    public static Put get(String s) {
+      for (Put put : values()) {
+        if (put.val.equals(s)) return put;
+      }
+      return null;
+    }
+  }
 
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Policy.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Policy.java
@@ -553,7 +553,7 @@ public class Policy implements MapWriter {
           if (!withCollMap.isEmpty()) {
             Clause withCollClause = new Clause((Map<String,Object>)Utils.fromJSONString("{withCollection:'*' , node: '#ANY'}") ,
                 new Condition(NODE.tagName, "#ANY", Operand.EQUAL, null, null),
-                new Condition(WITH_COLLECTION.tagName,"*" , Operand.EQUAL, null, null), true, false
+                new Condition(WITH_COLLECTION.tagName,"*" , Operand.EQUAL, null, null), true, null, false
             );
             expandedClauses.add(withCollClause);
           }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Policy.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Policy.java
@@ -553,7 +553,7 @@ public class Policy implements MapWriter {
           if (!withCollMap.isEmpty()) {
             Clause withCollClause = new Clause((Map<String,Object>)Utils.fromJSONString("{withCollection:'*' , node: '#ANY'}") ,
                 new Condition(NODE.tagName, "#ANY", Operand.EQUAL, null, null),
-                new Condition(WITH_COLLECTION.tagName,"*" , Operand.EQUAL, null, null), true
+                new Condition(WITH_COLLECTION.tagName,"*" , Operand.EQUAL, null, null), true, false
             );
             expandedClauses.add(withCollClause);
           }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Variable.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Variable.java
@@ -214,8 +214,9 @@ public interface Variable {
     @Meta(name = "STRING",
         type = String.class,
         wildCards = Policy.EACH,
-        supportArrayVals = true)
-    STRING,
+        supportArrayVals = true
+    )
+    SYSPROP,
 
     @Meta(name = "node",
         type = String.class,

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/VariableBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/VariableBase.java
@@ -45,6 +45,15 @@ public class VariableBase implements Variable {
     }
   }
 
+  @Override
+  public String postValidate(Condition condition) {
+    if(Clause.IGNORE_TAGS.contains(condition.getName())) return null;
+    if(condition.getOperand() == Operand.WILDCARD && condition.clause.nodeSetPresent){
+      return "#EACH not supported in tags in nodeset";
+    }
+    return null;
+  }
+
   static Object getOperandAdjustedValue(Object val, Object original) {
     if (original instanceof Condition) {
       Condition condition = (Condition) original;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/VariableBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/VariableBase.java
@@ -93,7 +93,7 @@ public class VariableBase implements Variable {
 
   public static Type getTagType(String name) {
     Type info = Type.get(name);
-    if (info == null && name.startsWith(ImplicitSnitch.SYSPROP)) info = Type.STRING;
+    if (info == null && name.startsWith(ImplicitSnitch.SYSPROP)) info = Type.SYSPROP;
     if (info == null && name.startsWith(Clause.METRICS_PREFIX)) info = Type.LAZY;
     return info;
   }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy.java
@@ -701,7 +701,7 @@ public class TestPolicy extends SolrTestCaseJ4 {
     expectThrows(IllegalArgumentException.class,
         () -> Clause.create("{cores: '>14%' , node:'#ANY'}"));
      clause  = Clause.create("{replica:1, nodeset : {sysprop.zone : east}}");
-     assertEquals(Variable.Type.STRING, clause.tag.varType);
+     assertEquals(Variable.Type.SYSPROP, clause.tag.varType);
      clause  =Clause.create("{replica:1, nodeset : [node1, node2, node3]}");
      assertEquals(Variable.Type.NODE, clause.tag.varType);
      assertEquals(Operand.IN, clause.tag.op);
@@ -719,7 +719,12 @@ public class TestPolicy extends SolrTestCaseJ4 {
         () -> Clause.create("{replica:1, nodeset : {sysprop.zone : east  , port: 8983 }}"));
     assertTrue(exp.getMessage().contains("nodeset must only have one and only one key"));
     clause = Clause.create("{'replica': '#ALL', 'nodeset': {'freedisk': '>700'}, 'strict': false}");
+    assertEquals(clause.put, Clause.Put.ON_ALL);
     assertEquals(Operand.GREATER_THAN , clause.tag.op);
+    clause = Clause.create("{'replica': '#ALL', put: on-each,  'nodeset': {sysprop.zone : east}}");
+    assertEquals(clause.put, Clause.Put.ON_EACH);
+    exp = expectThrows(IllegalArgumentException.class, ()-> Clause.create("{'replica': '#ALL', put: on-Each,  'nodeset': {sysprop.zone : east}}"));
+    assertTrue(exp.getMessage().contains("invalid value for put : on-Each"));
 
   }
 
@@ -1240,8 +1245,8 @@ public class TestPolicy extends SolrTestCaseJ4 {
           "  'cluster-policy': [" +
           "    { 'replica': 0, nodeset : {'nodeRole': 'overseer'}}" +
           "    { 'replica': '<2', 'shard': '#EACH', 'node': '#ANY'}," +
-          "    { 'replica': 0, 'shard': '#EACH', nodeset : { sysprop.fs : '!ssd'},  type : TLOG }" +
-          "    { 'replica': 0, 'shard': '#EACH', nodeset : {sysprop.fs : '!slowdisk'} ,  type : PULL }" +
+          "    { 'replica': 0, 'shard': '#EACH',  nodeset : { sysprop.fs : '!ssd'},  type : TLOG }" +
+          "    { 'replica': 0, 'shard': '#EACH', put:'on-each' nodeset : {sysprop.fs : '!slowdisk'} ,  type : PULL }" +
           "  ]" +
           "}");
 
@@ -1366,8 +1371,8 @@ public class TestPolicy extends SolrTestCaseJ4 {
           "    { 'replica': '<2', 'shard': '#EACH', 'node': '#ANY', 'collection':'newColl'}," +
           "    { 'replica': '<2', 'shard': '#EACH', 'node': '#ANY', 'collection':'newColl2', type : PULL}," +
           "    { 'replica': '<3', 'shard': '#EACH', 'node': '#ANY', 'collection':'newColl2'}," +
-          "    { 'replica': 0, 'shard': '#EACH', nodeset:{ sysprop.fs : '!ssd'},  type : TLOG }" +
-          "    { 'replica': 0, 'shard': '#EACH', nodeset : {sysprop.fs : '!slowdisk'} ,  type : PULL }" +
+          "    { 'replica': 0, 'shard': '#EACH', put: on-each , nodeset:{ sysprop.fs : '!ssd'},  type : TLOG }" +
+          "    { 'replica': 0, 'shard': '#EACH', put: on-each ,nodeset : {sysprop.fs : '!slowdisk'} ,  type : PULL }" +
           "  ]" +
           "}");
 
@@ -2389,8 +2394,8 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "  cluster-preferences :[{ minimize : cores, precision : 2 }]}";
     if(useNodeset){
       autoScalingjson = "  { cluster-policy:[" +
-          "    { replica :'0', nodeset:{ freedisk:'<1000'}}," +
-          "    { replica :0, nodeset : {nodeRole : overseer}}]," +
+          "    { replica :'0', put:on-each ,   nodeset:{ freedisk:'<1000'}}," +
+          "    { replica :0, put : on-each , nodeset : {nodeRole : overseer}}]," +
           "  cluster-preferences :[{ minimize : cores, precision : 2 }]}";
     }
     AutoScalingConfig cfg = new AutoScalingConfig((Map<String, Object>) Utils.fromJSONString(autoScalingjson));
@@ -2422,7 +2427,7 @@ public class TestPolicy extends SolrTestCaseJ4 {
     if(useNodeset){
       autoScalingjson =  "  { cluster-policy:[" +
           "    { replica :'#ALL', nodeset:{ freedisk:'>1000'}}," +
-          "    { replica :0 , nodeset : {nodeRole : overseer}}]," +
+          "    { replica :0 , put: on-each , nodeset : {nodeRole : overseer}}]," +
           "  cluster-preferences :[{ minimize : cores, precision : 2 }]}";
     }
     cfg = new AutoScalingConfig((Map<String, Object>) Utils.fromJSONString(autoScalingjson));

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy.java
@@ -707,6 +707,12 @@ public class TestPolicy extends SolrTestCaseJ4 {
      assertEquals(Operand.IN, clause.tag.op);
 
     expectThrows(IllegalArgumentException.class,
+        () -> Clause.create("{replica:1, nodeset : {sysprop.zone : '#EACH'}}"));
+
+    expectThrows(IllegalArgumentException.class,
+        () -> Clause.create("{replica:1, nodeset : {host : '#EACH'}}"));
+
+    expectThrows(IllegalArgumentException.class,
         () -> Clause.create("{replica:1, node: n1, nodeset : {sysprop.zone : east}}"));
 
     IllegalArgumentException exp = expectThrows(IllegalArgumentException.class,
@@ -1912,7 +1918,7 @@ public class TestPolicy extends SolrTestCaseJ4 {
           "{replica:0, nodeset:{'nodeRole':'overseer'},'strict':false}," +
           "{'replica':'<1','node':'node3'}," +
           "{'replica':'<2','node':'#ANY','shard':'#EACH'}," +
-          "{'replica':'<3','shard':'#EACH', nodeset : { 'sysprop.rack':'#EACH'}}" +
+          "{'replica':'<3','shard':'#EACH', nodeset : { 'sysprop.rack':[rack1, rack2, rack3, rack4]}}" +
           "]" +
           "}" +
           "}";

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy.java
@@ -86,8 +86,12 @@ import static org.apache.solr.common.params.CollectionParams.CollectionAction.AD
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.MOVEREPLICA;
 
 public class TestPolicy extends SolrTestCaseJ4 {
+  boolean useNodeset ;
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  public TestPolicy(){
+    useNodeset = true;
+  }
   static Suggester createSuggester(SolrCloudManager cloudManager, Map jsonObj, Suggester seed) throws IOException, InterruptedException {
     Policy.Session session = null;
     if (seed != null) session = seed.session;
@@ -696,6 +700,20 @@ public class TestPolicy extends SolrTestCaseJ4 {
 
     expectThrows(IllegalArgumentException.class,
         () -> Clause.create("{cores: '>14%' , node:'#ANY'}"));
+     clause  = Clause.create("{replica:1, nodeset : {sysprop.zone : east}}");
+     assertEquals(Variable.Type.STRING, clause.tag.varType);
+     clause  =Clause.create("{replica:1, nodeset : [node1, node2, node3]}");
+     assertEquals(Variable.Type.NODE, clause.tag.varType);
+     assertEquals(Operand.IN, clause.tag.op);
+
+    expectThrows(IllegalArgumentException.class,
+        () -> Clause.create("{replica:1, node: n1, nodeset : {sysprop.zone : east}}"));
+
+    IllegalArgumentException exp = expectThrows(IllegalArgumentException.class,
+        () -> Clause.create("{replica:1, nodeset : {sysprop.zone : east  , port: 8983 }}"));
+    assertTrue(exp.getMessage().contains("nodeset must only have one and only one key"));
+    clause = Clause.create("{'replica': '#ALL', 'nodeset': {'freedisk': '>700'}, 'strict': false}");
+    assertEquals(Operand.GREATER_THAN , clause.tag.op);
 
   }
 
@@ -976,6 +994,19 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "    { 'replica': '<2', 'shard': '#EACH', 'node': '#ANY'}," +
         "  ]" +
         "}");
+
+    if(useNodeset) {
+      policies = (Map) Utils.fromJSONString("{" +
+          "  'cluster-preferences': [" +
+          "    { 'maximize': 'freedisk', 'precision': 50}," +
+          "    { 'minimize': 'cores', 'precision': 50}" +
+          "  ]," +
+          "  'cluster-policy': [" +
+          "    { 'replica': 0, nodeset:{'nodeRole': 'overseer'}}" +
+          "    { 'replica': '<2', 'shard': '#EACH', 'node': '#ANY'}," +
+          "  ]" +
+          "}");
+    }
     AutoScalingConfig config = new AutoScalingConfig(policies);
     Policy policy = config.getPolicy();
     Policy.Session session = policy.createSession(provider);
@@ -1011,6 +1042,19 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "    { 'replica': '<3', 'shard': '#EACH', 'node': '#ANY'}," +
         "  ]" +
         "}");
+    if(useNodeset){
+      policies = (Map) Utils.fromJSONString("{" +
+          "  'cluster-preferences': [" +
+          "    { 'maximize': 'freedisk', 'precision': 50}," +
+          "    { 'minimize': 'cores', 'precision': 50}" +
+          "  ]," +
+          "  'cluster-policy': [" +
+          "    { 'replica': 0, nodeset: {'nodeRole': 'overseer'}}" +
+          "    { 'replica': '<3', 'shard': '#EACH', 'node': '#ANY'}," +
+          "  ]" +
+          "}");
+
+    }
     config = new AutoScalingConfig(policies);
     policy = config.getPolicy();
     session = policy.createSession(provider);
@@ -1055,6 +1099,20 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "    { 'replica': '<3', 'shard': 'shard2', 'node': '#ANY'}," +
         "  ]" +
         "}");
+    if(useNodeset){
+      policies = (Map) Utils.fromJSONString("{" +
+          "  'cluster-preferences': [" +
+          "    { 'maximize': 'freedisk', 'precision': 50}," +
+          "    { 'minimize': 'cores', 'precision': 50}" +
+          "  ]," +
+          "  'cluster-policy': [" +
+          "    { 'replica': 0, nodeset:{'nodeRole': 'overseer'}}" +
+          "    { 'replica': '<2', 'shard': 'shard1', 'node': '#ANY'}," +
+          "    { 'replica': '<3', 'shard': 'shard2', 'node': '#ANY'}," +
+          "  ]" +
+          "}");
+
+    }
     config = new AutoScalingConfig(policies);
     policy = config.getPolicy();
     session = policy.createSession(provider);
@@ -1167,6 +1225,21 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "    { 'replica': 0, 'shard': '#EACH', sysprop.fs : '!slowdisk' ,  type : PULL }" +
         "  ]" +
         "}");
+    if(useNodeset){
+      policies = (Map) Utils.fromJSONString("{" +
+          "  'cluster-preferences': [" +
+          "    { 'maximize': 'freedisk', 'precision': 50}," +
+          "    { 'minimize': 'cores', 'precision': 50}" +
+          "  ]," +
+          "  'cluster-policy': [" +
+          "    { 'replica': 0, nodeset : {'nodeRole': 'overseer'}}" +
+          "    { 'replica': '<2', 'shard': '#EACH', 'node': '#ANY'}," +
+          "    { 'replica': 0, 'shard': '#EACH', nodeset : { sysprop.fs : '!ssd'},  type : TLOG }" +
+          "    { 'replica': 0, 'shard': '#EACH', nodeset : {sysprop.fs : '!slowdisk'} ,  type : PULL }" +
+          "  ]" +
+          "}");
+
+    }
     Map<String, Map> nodeValues = (Map<String, Map>) Utils.fromJSONString("{" +
         "node1:{cores:12, freedisk: 334, heapUsage:10480, rack: rack4, sysprop.fs: slowdisk}," +
         "node2:{cores:4, freedisk: 749, heapUsage:6873, rack: rack3, sysprop.fs: unknown }," +
@@ -1276,6 +1349,23 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "    { 'replica': 0, 'shard': '#EACH', sysprop.fs : '!slowdisk' ,  type : PULL }" +
         "  ]" +
         "}");
+    if(useNodeset){
+      policies = (Map) Utils.fromJSONString("{" +
+          "  'cluster-preferences': [" +
+          "    { 'maximize': 'freedisk', 'precision': 50}," +
+          "    { 'minimize': 'cores', 'precision': 1}" +
+          "  ]," +
+          "  'cluster-policy': [" +
+          "    { 'replica': 0, nodeset : {'nodeRole': 'overseer'}}" +
+          "    { 'replica': '<2', 'shard': '#EACH', 'node': '#ANY', 'collection':'newColl'}," +
+          "    { 'replica': '<2', 'shard': '#EACH', 'node': '#ANY', 'collection':'newColl2', type : PULL}," +
+          "    { 'replica': '<3', 'shard': '#EACH', 'node': '#ANY', 'collection':'newColl2'}," +
+          "    { 'replica': 0, 'shard': '#EACH', nodeset:{ sysprop.fs : '!ssd'},  type : TLOG }" +
+          "    { 'replica': 0, 'shard': '#EACH', nodeset : {sysprop.fs : '!slowdisk'} ,  type : PULL }" +
+          "  ]" +
+          "}");
+
+    }
     Map<String, Map> nodeValues = (Map<String, Map>) Utils.fromJSONString("{" +
         "node1:{cores:12, freedisk: 334, heapUsage:10480, rack: rack4, sysprop.fs: slowdisk}," +
         "node2:{cores:4, freedisk: 749, heapUsage:6873, rack: rack3, sysprop.fs: unknown}," +
@@ -1400,6 +1490,26 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "    ]" +
         "  }" +
         "}");
+    if(useNodeset){
+      map = (Map) Utils.fromJSONString("{" +
+          "  'cluster-preferences': [" +
+          "    { 'maximize': 'freedisk', 'precision': 50}," +
+          "    { 'minimize': 'cores', 'precision': 50}" +
+          "  ]," +
+          "  'cluster-policy': [" +
+          "    { 'replica': 0, nodeset: {'nodeRole': 'overseer'}}," +
+          "    { 'replica': '<2', 'shard': '#EACH', 'node': '#ANY'}" +
+          "  ]," +
+          "  'policies': {" +
+          "    'policy1': [" +
+          "      { 'replica': '1', nodeset:{ 'sysprop.fs': 'ssd'}, 'shard': '#EACH'}," +
+          "      { 'replica': '<2', 'shard': '#ANY', 'node': '#ANY'}," +
+          "      { 'replica': '<2', 'shard': '#EACH',nodeset:{ 'sysprop.rack': 'rack1'}}" +
+          "    ]" +
+          "  }" +
+          "}");
+
+    }
     Policy policy = new Policy(map);
     List<Clause> clauses = Policy.mergePolicies("mycoll", policy.getPolicies().get("policy1"), policy.getClusterPolicy());
     Collections.sort(clauses);
@@ -1407,8 +1517,8 @@ public class TestPolicy extends SolrTestCaseJ4 {
     assertEquals("1", String.valueOf(clauses.get(0).original.get("replica")));
     assertEquals("0", String.valueOf(clauses.get(1).original.get("replica")));
     assertEquals("#ANY", clauses.get(3).original.get("shard"));
-    assertEquals("rack1", clauses.get(2).original.get("sysprop.rack"));
-    assertEquals("overseer", clauses.get(1).original.get("nodeRole"));
+    assertEquals("rack1", clauses.get(2).tag.val);
+    assertEquals("overseer",clauses.get(1).tag.val);
   }
 
   public void testConditionsSort() {
@@ -1419,6 +1529,16 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "      { 'replica':'<2', 'node':'#ANY', 'shard':'#EACH'}," +
         "      { 'replica':1, 'sysprop.rack':'rack1'}]" +
         "  }";
+    if(useNodeset){
+      rules = "{" +
+          "    'cluster-policy':[" +
+          "      { 'nodeRole':'overseer', replica: 0,  'strict':false}," +
+          "      { 'replica':'<1', 'node':'node3', 'shard':'#EACH'}," +
+          "      { 'replica':'<2', 'node':'#ANY', 'shard':'#EACH'}," +
+          "      { 'replica':1, nodeset: {'sysprop.rack':'rack1'}}]" +
+          "  }";
+
+    }
     Policy p = new Policy((Map<String, Object>) Utils.fromJSONString(rules));
     List<Clause> clauses = new ArrayList<>(p.getClusterPolicy());
     Collections.sort(clauses);
@@ -1436,6 +1556,17 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "{minimize:cores , precision:2}," +
         "{maximize:freedisk, precision:50}, " +
         "{minimize:heapUsage, precision:1000}]}";
+    if(useNodeset){
+      rules = "{" +
+          "cluster-policy:[" +
+          "{nodeset:{nodeRole:'overseer'},replica : 0 , strict:false}," +
+          "{replica:'<1',node:node3}," +
+          "{replica:'<2',node:'#ANY', shard:'#EACH'}]," +
+          " cluster-preferences:[" +
+          "{minimize:cores , precision:2}," +
+          "{maximize:freedisk, precision:50}, " +
+          "{minimize:heapUsage, precision:1000}]}";
+    }
 
     Map<String, Map> nodeValues = (Map<String, Map>) Utils.fromJSONString("{" +
         "node1:{cores:12, freedisk: 334, heapUsage:10480}," +
@@ -1624,6 +1755,18 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "      'cluster-preferences':[" +
         "      {'minimize':'cores', 'precision':3}," +
         "      {'maximize':'freedisk','precision':100}]}";
+    if(useNodeset){
+      autoscaleJson = "{" +
+          "      'cluster-policy':[" +
+          "      {'cores':'<10','node':'#ANY'}," +
+          "      {'replica':'<3','shard':'#EACH','node':'#ANY'}," +
+          "      { 'replica': 2, nodeset: {'sysprop.fs': 'ssd'}, 'shard': '#EACH'}," +//greedy condition
+          "      {nodeset:{'nodeRole':'overseer'},'replica':'0'}]," +
+          "      'cluster-preferences':[" +
+          "      {'minimize':'cores', 'precision':3}," +
+          "      {'maximize':'freedisk','precision':100}]}";
+
+    }
     Map<String, Map> nodeValues = (Map<String, Map>) Utils.fromJSONString("{" +
         "node1:{cores:12, freedisk: 334, heapUsage:10480, rack: rack4}," +
         "node2:{cores:4, freedisk: 749, heapUsage:6873, rack: rack3}," +
@@ -1667,6 +1810,17 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "      {'minimize':'cores', 'precision':3}," +
         "      {'maximize':'freedisk','precision':100}]}";
 
+    if(useNodeset){
+      autoscaleJson = "{" +
+          "      'cluster-policy':[" +
+          "      {'cores':'<10','node':'#ANY'}," +
+          "      {'replica':'<3','shard':'#EACH','node':'#ANY'}," +
+          "      {nodeset: {'nodeRole':'overseer'},'replica':'0'}]," +
+          "      'cluster-preferences':[" +
+          "      {'minimize':'cores', 'precision':3}," +
+          "      {'maximize':'freedisk','precision':100}]}";
+
+    }
 
     Map replicaInfoMap = (Map) Utils.fromJSONString("{ '127.0.0.1:60099_solr':{}," +
         " '127.0.0.1:60089_solr':{'compute_plan_action_test':{'shard1':[" +
@@ -1740,6 +1894,31 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "]" +
         "}" +
         "}";
+
+    if(useNodeset){
+      rules = "{" +
+          "'cluster-preferences':[" +
+          "{'minimize':'cores','precision':2}," +
+          "{'maximize':'freedisk','precision':50}," +
+          "{'minimize':'heapUsage','precision':1000}" +
+          "]," +
+          "'cluster-policy':[" +
+          "{replica:0, nodeset:{'nodeRole':'overseer'},'strict':false}," +
+          "{'replica':'<1','node':'node3'}," +
+          "{'replica':'<2','node':'#ANY','shard':'#EACH'}" +
+          "]," +
+          "'policies':{" +
+          "'p1':[" +
+          "{replica:0, nodeset:{'nodeRole':'overseer'},'strict':false}," +
+          "{'replica':'<1','node':'node3'}," +
+          "{'replica':'<2','node':'#ANY','shard':'#EACH'}," +
+          "{'replica':'<3','shard':'#EACH', nodeset : { 'sysprop.rack':'#EACH'}}" +
+          "]" +
+          "}" +
+          "}";
+
+
+    }
 
     Map<String, Map> nodeValues = (Map<String, Map>) Utils.fromJSONString("{" +
         "node1:{cores:12, freedisk: 334, heapUsage:10480, rack: rack4}," +
@@ -1928,6 +2107,26 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "    ]" +
         "  }" +
         "}";
+    if(useNodeset){
+      autoScaleJson = "{" +
+          "  cluster-preferences: [" +
+          "    { maximize : freedisk , precision: 50}," +
+          "    { minimize : cores, precision: 2}" +
+          "  ]," +
+          "  cluster-policy: [" +
+          "    { replica : '0' , nodeset: {nodeRole: overseer}}," +
+          "    { replica: '<2', shard: '#ANY', node: '#ANY'" +
+          "    }" +
+          "  ]," +
+          "  policies: {" +
+          "    policy1: [" +
+          "      { replica: '<2', shard: '#EACH', node: '#ANY'}," +
+          "      { replica: '<2', shard: '#EACH', nodeset:{ sysprop.rack: rack1}}" +
+          "    ]" +
+          "  }" +
+          "}";
+
+    }
 
 
     Map<String, Map> nodeValues = (Map<String, Map>) Utils.fromJSONString("{" +
@@ -2003,6 +2202,15 @@ public class TestPolicy extends SolrTestCaseJ4 {
         " cluster-policy:[{cores:'<10',node:'#ANY'}," +
         "       {replica:'<2', shard:'#EACH',node:'#ANY'}," +
         "       { nodeRole:overseer,replica:0}]}";
+    if(useNodeset){
+      autoScalingjson = "cluster-preferences:[" +
+          "       {minimize : cores}," +
+          "       {'maximize':freedisk , precision:100}],    " +
+          " cluster-policy:[{cores:'<10',node:'#ANY'}," +
+          "       {replica:'<2', shard:'#EACH',node:'#ANY'}," +
+          "       {nodeset:{ nodeRole:overseer},replica:0}]}";
+
+    }
     Policy policy = new Policy((Map<String, Object>) Utils.fromJSONString(autoScalingjson));
     Policy.Session session = policy.createSession(cloudManagerWithData((Map) loadFromResource("testComputePlanAfterNodeAdded.json")));
     Suggester suggester = session.getSuggester(CollectionParams.CollectionAction.MOVEREPLICA)
@@ -2018,6 +2226,14 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "    { replica :'<2',  node:'#ANY'}," +
         "    { nodeRole : overseer, replica :0}]," +
         "  cluster-preferences :[{ minimize : cores }]}";
+    if(useNodeset){
+      autoScalingjson = "  { cluster-policy:[" +
+          "    { cores :'<10', node :'#ANY'}," +
+          "    { replica :'<2',  node:'#ANY'}," +
+          "    { nodeset:{nodeRole : overseer}, replica :0}]," +
+          "  cluster-preferences :[{ minimize : cores }]}";
+
+    }
     List<Suggester.SuggestionInfo> l = PolicyHelper.getSuggestions(new AutoScalingConfig((Map<String, Object>) Utils.fromJSONString(autoScalingjson)),
         cloudManagerWithData((Map) loadFromResource("testReplicaCountSuggestions.json")));
     assertFalse(l.isEmpty());
@@ -2123,6 +2339,12 @@ public class TestPolicy extends SolrTestCaseJ4 {
   public void testFreeDiskDeviation() {
     Map map = (Map) loadFromResource("testFreeDiskDeviation.json");
     AutoScalingConfig cfg = new AutoScalingConfig((Map<String, Object>) map.get("config"));
+    if(useNodeset){
+      cfg = new AutoScalingConfig((Map<String, Object>) Utils.fromJSONString("{" +
+          "    'cluster-policy': [{'replica':'<2', 'shard':'#EACH', 'node':'#ANY'}," +
+          "      {'replica': '#ALL', 'nodeset': {'freedisk': '>700'}, 'strict': false}]" +
+          "  }"));
+    }
     SolrCloudManager scm = cloudManagerWithData(map);
     Suggester suggester = cfg.getPolicy()
         .createSession(scm)
@@ -2159,6 +2381,12 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "    { replica :'0', freedisk:'<1000'}," +
         "    { nodeRole : overseer, replica :0}]," +
         "  cluster-preferences :[{ minimize : cores, precision : 2 }]}";
+    if(useNodeset){
+      autoScalingjson = "  { cluster-policy:[" +
+          "    { replica :'0', nodeset:{ freedisk:'<1000'}}," +
+          "    { replica :0, nodeset : {nodeRole : overseer}}]," +
+          "  cluster-preferences :[{ minimize : cores, precision : 2 }]}";
+    }
     AutoScalingConfig cfg = new AutoScalingConfig((Map<String, Object>) Utils.fromJSONString(autoScalingjson));
     List<Violation> violations = cfg.getPolicy().createSession(cloudManagerWithData((Map) loadFromResource("testFreeDiskSuggestions.json"))).getViolations();
     assertEquals(1, violations.size());
@@ -2185,6 +2413,12 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "    { replica :'#ALL', freedisk:'>1000'}," +
         "    { nodeRole : overseer, replica :0}]," +
         "  cluster-preferences :[{ minimize : cores, precision : 2 }]}";
+    if(useNodeset){
+      autoScalingjson =  "  { cluster-policy:[" +
+          "    { replica :'#ALL', nodeset:{ freedisk:'>1000'}}," +
+          "    { replica :0 , nodeset : {nodeRole : overseer}}]," +
+          "  cluster-preferences :[{ minimize : cores, precision : 2 }]}";
+    }
     cfg = new AutoScalingConfig((Map<String, Object>) Utils.fromJSONString(autoScalingjson));
     violations = cfg.getPolicy().createSession(cloudManagerWithData((Map) loadFromResource("testFreeDiskSuggestions.json"))).getViolations();
     assertEquals(1, violations.size());
@@ -2237,6 +2471,17 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "    { 'replica': '1', shard:'#EACH', sysprop.fs : 'ssd'}" +
         "  ]" +
         "}";
+    if(useNodeset){
+      autoScalingjson = "{" +
+          "  'cluster-preferences': [" +
+          "    { 'maximize': 'freedisk', 'precision': 50}," +
+          "    { 'minimize': 'cores', 'precision': 3}" +
+          "  ]," +
+          "  'cluster-policy': [" +
+          "    { 'replica': '1', shard:'#EACH', nodeset:{ sysprop.fs : 'ssd'}}" +
+          "  ]" +
+          "}";
+    }
 
 
     AutoScalingConfig cfg = new AutoScalingConfig((Map<String, Object>) Utils.fromJSONString(autoScalingjson));
@@ -2260,6 +2505,18 @@ public class TestPolicy extends SolrTestCaseJ4 {
         "  ]" +
         "}";
 
+    if(useNodeset){
+      autoScalingjson = "{" +
+          "  'cluster-preferences': [" +
+          "    { 'maximize': 'freedisk', 'precision': 50}," +
+          "    { 'minimize': 'cores', 'precision': 3}" +
+          "  ]," +
+          "  'cluster-policy': [" +
+          "    { 'replica': 0, shard:'#EACH', nodeset :{ port : '8983'}}" +
+          "  ]" +
+          "}";
+
+    }
     AutoScalingConfig cfg = new AutoScalingConfig((Map<String, Object>) Utils.fromJSONString(autoScalingjson));
     List<Violation> violations = cfg.getPolicy().createSession(cloudManagerWithData((Map) loadFromResource("testPortSuggestions.json"))).getViolations();
     assertEquals(2, violations.size());

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy2.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy2.java
@@ -87,7 +87,7 @@ public class TestPolicy2 extends SolrTestCaseJ4 {
         "  'cluster-preferences':[{ minimize : cores},{maximize : freedisk, precision : 50}]}";
     if(useNodeset){
       autoScalingjson = "{cluster-policy:[" +
-          "    { replica : '<3' , shard : '#EACH', nodeset:{sysprop.zone: '#EACH'} } ]," +
+          "    { replica : '<3' , shard : '#EACH', nodeset:{sysprop.zone: [east , west]} } ]," +
           "  'cluster-preferences':[{ minimize : cores},{maximize : freedisk, precision : 50}]}";
     }
     policy = new Policy((Map<String, Object>) Utils.fromJSONString(autoScalingjson));

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy2.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy2.java
@@ -53,6 +53,11 @@ import static org.apache.solr.common.util.Utils.MAPOBJBUILDER;
 import static org.apache.solr.common.util.Utils.getObjectByPath;
 
 public class TestPolicy2 extends SolrTestCaseJ4 {
+  boolean useNodeset ;
+  public TestPolicy2(){
+    useNodeset = true;
+  }
+
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   public void testEqualOnNonNode() {
@@ -60,6 +65,12 @@ public class TestPolicy2 extends SolrTestCaseJ4 {
     String autoScalingjson = "{cluster-policy:[" +
         "    { replica : '<3' , shard : '#EACH', sysprop.zone: [east,west] } ]," +
         "  'cluster-preferences':[{ minimize : cores},{maximize : freedisk, precision : 50}]}";
+    if(useNodeset){
+      autoScalingjson = "{cluster-policy:[" +
+          "    { replica : '<3' , shard : '#EACH', nodeset:{ sysprop.zone: [east,west] }} ]," +
+          "  'cluster-preferences':[{ minimize : cores},{maximize : freedisk, precision : 50}]}";
+      
+    }
     Policy policy = new Policy((Map<String, Object>) Utils.fromJSONString(autoScalingjson));
     Policy.Session session = policy.createSession(createCloudManager(l.get(0), l.get(1)));
     List<Violation> violations = session.getViolations();
@@ -74,6 +85,11 @@ public class TestPolicy2 extends SolrTestCaseJ4 {
     autoScalingjson = "{cluster-policy:[" +
         "    { replica : '<3' , shard : '#EACH', sysprop.zone: '#EACH' } ]," +
         "  'cluster-preferences':[{ minimize : cores},{maximize : freedisk, precision : 50}]}";
+    if(useNodeset){
+      autoScalingjson = "{cluster-policy:[" +
+          "    { replica : '<3' , shard : '#EACH', nodeset:{sysprop.zone: '#EACH'} } ]," +
+          "  'cluster-preferences':[{ minimize : cores},{maximize : freedisk, precision : 50}]}";
+    }
     policy = new Policy((Map<String, Object>) Utils.fromJSONString(autoScalingjson));
     session = policy.createSession(createCloudManager(l.get(0), l.get(1)));
     violations = session.getViolations();
@@ -335,6 +351,22 @@ public class TestPolicy2 extends SolrTestCaseJ4 {
     Map<String, Object> m = (Map<String, Object>) loadFromResource("testSysPropSuggestions.json");
 
     Map<String, Object> conf = (Map<String, Object>) getObjectByPath(m, false, "diagnostics/config");
+    if(useNodeset){
+      conf = (Map<String, Object>) Utils.fromJSONString("{" +
+          "    'cluster-preferences':[{" +
+          "      'minimize':'cores'," +
+          "      'precision':1}," +
+          "      {" +
+          "        'maximize':'freedisk'," +
+          "        'precision':100}," +
+          "      {" +
+          "        'minimize':'sysLoadAvg'," +
+          "        'precision':10}]," +
+          "    'cluster-policy':[{" +
+          "      'replica':'<3'," +
+          "      'shard':'#EACH'," +
+          "      nodeset: {'sysprop.zone':['east','west']}}]}");
+    }
     Policy policy = new Policy(conf);
     SolrCloudManager cloudManagerFromDiagnostics = createCloudManagerFromDiagnostics(m);
     Policy.Session session = policy.createSession(cloudManagerFromDiagnostics);
@@ -361,6 +393,17 @@ public class TestPolicy2 extends SolrTestCaseJ4 {
         "      {'minimize':'sysLoadAvg','precision':10}]," +
         "    'cluster-policy':[" +
         "{'replica':'<5','shard':'#EACH','sysprop.zone':['east','west']}]}";
+    if(useNodeset){
+      conf = " {" +
+          "    'cluster-preferences':[{" +
+          "      'minimize':'cores'," +
+          "      'precision':1}," +
+          "      {'maximize':'freedisk','precision':100}," +
+          "      {'minimize':'sysLoadAvg','precision':10}]," +
+          "    'cluster-policy':[" +
+          "{'replica':'<5','shard':'#EACH', nodeset:{'sysprop.zone':['east','west']}}]}";
+
+    }
     Map<String, Object> m = (Map<String, Object>) loadFromResource("testSuggestionsRebalanceOnly.json");
     SolrCloudManager cloudManagerFromDiagnostics = createCloudManagerFromDiagnostics(m);
     AutoScalingConfig autoScalingConfig = new AutoScalingConfig((Map<String, Object>) Utils.fromJSONString(conf));

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy2Old.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicy2Old.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.client.solrj.cloud.autoscaling;
+
+public class TestPolicy2Old extends TestPolicy2 {
+  public TestPolicy2Old(){
+    super();
+    useNodeset = false;
+  }
+
+}

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicyOld.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/cloud/autoscaling/TestPolicyOld.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.client.solrj.cloud.autoscaling;
+
+public class TestPolicyOld extends TestPolicy {
+  public TestPolicyOld(){
+    super();
+    useNodeset = false;
+  }
+}


### PR DESCRIPTION
* SOLR-13504: In autoscaling policies, use an explicit 'nodeset' attribute for filtering
  nodes instead of using them directly at the toplevel (Generally available from SOLR 8.2)(noble)
* SOLR-13329: In autoscaling policies, use an explicit 'put : on-each'
  to specify the the rules is applied on each node (Generally available from SOLR 8.2)(noble)
