### PR TITLE
SOLR-13349: High CPU usage in Solr due to Java 8 bug

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -16,6 +16,22 @@ In this release, there is an example Solr server including a bundled
 servlet container in the directory named "example".
 See the Solr tutorial at https://lucene.apache.org/solr/guide/solr-tutorial.html
 
+==================  7.7.2 ==================
+
+Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.
+
+Versions of Major Components
+---------------------
+Apache Tika 1.19.1
+Carrot2 3.16.0
+Velocity 1.7 and Velocity Tools 2.0
+Apache ZooKeeper 3.4.13
+Jetty 9.4.14.v20181114
+
+Bug Fixes
+----------------------
+
+* SOLR-13349: High CPU usage in Solr due to Java 8 bug (Erick Erickson)
 
 ==================  7.7.1 ==================
 

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -17,7 +17,6 @@
 package org.apache.solr.update;
 
 import java.lang.invoke.MethodHandles;
-
 import java.util.Locale;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -59,7 +58,7 @@ public final class CommitTracker implements Runnable {
   private long tLogFileSizeUpperBound;
   
   private final ScheduledExecutorService scheduler = 
-      Executors.newScheduledThreadPool(0, new DefaultSolrThreadFactory("commitScheduler"));
+      Executors.newScheduledThreadPool(1, new DefaultSolrThreadFactory("commitScheduler"));
   private ScheduledFuture pending;
   
   // state


### PR DESCRIPTION
CommitTracker makes this call:

Executors.newScheduledThreadPool(0, new DefaultSolrThreadFactory("commitScheduler"));

The supposition is that calling this with 1 will fix this (untested)

