### PR TITLE
FULLSTORY-CHANGES.txt, revert an inadvertent omission in previous commit

### DIFF
--- a/solr/FULLSTORY-CHANGES.txt
+++ b/solr/FULLSTORY-CHANGES.txt
@@ -3,6 +3,7 @@
 * SOLR-13718: SPLITSHARD (async) with failures in underlying sub-operations can result in data loss (Generally available from 8.3)(Ishan Chattopadhyaya)
 * SOLR-12291: prematurely reporting not yet finished async Collections API call as completed when collection's replicas are collocated at least at one node (Generally available from 8.1)
 * SOLR-12708: Async collection actions should not hide internal failures (Mano Kovacs, Varun Thacker, Tomás Fernández Löbbe)
+* SOLR-13320: add a param failOnVersionConflicts=false to updates not fail when there is a version conflict (Noble Paul, Scott Blum) (SOLR 8.2)
 * FullStory: special OOMKILLER handling for spaces (Scott Blum)
 * Remove pathological error reporting. Don't serialize the entire clusterstate to log (Generally available from SOLR 8.1)(Scott Blum)
 * Expose DocValuesTermsCollector and TermsQuery (Generally available from SOLR 8.1) (Jaime Yap) 


### PR DESCRIPTION
In the last PR, which I accidentally omitted an entry from the FULLSTORY-CHANGES.txt. Adding that back in.