### PR TITLE
fix for javadoc issue

### DIFF
--- a/lucene/common-build.xml
+++ b/lucene/common-build.xml
@@ -186,9 +186,10 @@
   <property name="javadoc.maxmemory" value="512m" />
   <property name="javadoc.noindex" value="true"/>
 
-  <property name="javadoc.doclint.args" value="-Xdoclint:all -Xdoclint:-missing"/>
+  <!---TODO: Fix accessibility (order of H1/H2/H3 headings), see https://issues.apache.org/jira/browse/LUCENE-8729 -->
+  <property name="javadoc.doclint.args" value="-Xdoclint:all -Xdoclint:-missing -Xdoclint:-accessibility"/>
   <!---proc:none was added because of LOG4J2-1925 / JDK-8186647 -->
-  <property name="javac.doclint.args" value="-Xdoclint:all/protected -Xdoclint:-missing -proc:none"/>
+  <property name="javac.doclint.args" value="-Xdoclint:all/protected -Xdoclint:-missing -Xdoclint:-accessibility -proc:none"/>
   
   <!-- Javadoc classpath -->
   <path id="javadoc.classpath">


### PR DESCRIPTION
context: http://mail-archives.apache.org/mod_mbox/lucene-dev/201903.mbox/%3CJIRA.13222272.1552904380000.88588.1553019300294@Atlassian.JIRA%3E

branch wasn't able to build because of this, so backporting patch in the bug report. if there's a better fix, please let me know! 