### PR TITLE
fixing build issues due to maven restlet repo changing

### DIFF
--- a/lucene/default-nested-ivy-settings.xml
+++ b/lucene/default-nested-ivy-settings.xml
@@ -34,7 +34,7 @@
   <resolvers>
     <ibiblio name="sonatype-releases" root="https://oss.sonatype.org/content/repositories/releases" m2compatible="true" />
     <ibiblio name="maven.restlet.com" root="https://maven.restlet.com" m2compatible="true" />
-    <ibiblio name="releases.cloudera.com" root="https://repository.cloudera.com/artifactory/libs-release-local" m2compatible="true" />
+    <ibiblio name="releases.cloudera.com" root="https://repository.cloudera.com/content/repositories/releases" m2compatible="true" />
 
     <!-- you might need to tweak this from china so it works -->
     <ibiblio name="working-chinese-mirror" root="http://uk.maven.org/maven2" m2compatible="true" />

--- a/lucene/default-nested-ivy-settings.xml
+++ b/lucene/default-nested-ivy-settings.xml
@@ -33,6 +33,8 @@
 
   <resolvers>
     <ibiblio name="sonatype-releases" root="https://oss.sonatype.org/content/repositories/releases" m2compatible="true" />
+    <!-- restlet was acquired, and the repo has been in flux. using maven.restlet.talentd.com might be required if it
+    changes again. -->
     <ibiblio name="maven.restlet.com" root="https://maven.restlet.com" m2compatible="true" />
     <ibiblio name="releases.cloudera.com" root="https://repository.cloudera.com/content/repositories/releases" m2compatible="true" />
 

--- a/lucene/default-nested-ivy-settings.xml
+++ b/lucene/default-nested-ivy-settings.xml
@@ -33,8 +33,8 @@
 
   <resolvers>
     <ibiblio name="sonatype-releases" root="https://oss.sonatype.org/content/repositories/releases" m2compatible="true" />
-    <ibiblio name="maven.restlet.org" root="http://maven.restlet.org" m2compatible="true" />
-    <ibiblio name="releases.cloudera.com" root="http://repository.cloudera.com/content/repositories/releases" m2compatible="true" />
+    <ibiblio name="maven.restlet.com" root="https://maven.restlet.com" m2compatible="true" />
+    <ibiblio name="releases.cloudera.com" root="https://repository.cloudera.com/artifactory/libs-release-local" m2compatible="true" />
 
     <!-- you might need to tweak this from china so it works -->
     <ibiblio name="working-chinese-mirror" root="http://uk.maven.org/maven2" m2compatible="true" />
@@ -50,10 +50,9 @@
       <resolver ref="local"/>
       <!-- <resolver ref="local-maven-2" /> -->
       <resolver ref="main"/>
-      <resolver ref="maven.restlet.org" />
+      <resolver ref="maven.restlet.com" />
       <resolver ref="sonatype-releases" />
       <resolver ref="releases.cloudera.com"/>
-      <resolver ref="working-chinese-mirror" />
     </chain>
   </resolvers>
 


### PR DESCRIPTION
see https://github.com/apache/lucene-solr/commit/ee532099c12759775583c523a7cc5108ba864d23

A different company acquired restlet, and while the maven repo still technically exists, it's not secured so maven won't download from there. This fixes the repo to the appropriate one. 

This is causing build issues that are blocking the plugin deployment efforts. 