### PR TITLE
Use correct magic serial for serializing responses

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrResponse.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrResponse.java
@@ -37,7 +37,7 @@ import org.apache.solr.common.util.NamedList;
 public abstract class SolrResponse implements Serializable, MapWriter {
 
   /** make this compatible with earlier versions */
-  private static final long serialVersionUID = 2239939671435624715;
+  private static final long serialVersionUID = 2239939671435624715L;
 
   /** Elapsed time in milliseconds for the request as seen from the client. */
   public abstract long getElapsedTime();

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrResponse.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrResponse.java
@@ -37,7 +37,7 @@ import org.apache.solr.common.util.NamedList;
 public abstract class SolrResponse implements Serializable, MapWriter {
 
   /** make this compatible with earlier versions */
-  private static final long serialVersionUID = -7931100103360242645L;
+  private static final long serialVersionUID = 2239939671435624715;
 
   /** Elapsed time in milliseconds for the request as seen from the client. */
   public abstract long getElapsedTime();


### PR DESCRIPTION
SOLR-14165 hotfix used wrong magic serial number (something that worked for 8.4, but not 7.7, apparently). 