### PR TITLE
bump lucene to https for maven calls

### DIFF
--- a/lucene/common-build.xml
+++ b/lucene/common-build.xml
@@ -410,9 +410,9 @@
   </target>
 
   <property name="ivy_install_path" location="${user.home}/.ant/lib" />
-  <property name="ivy_bootstrap_url1" value="http://repo1.maven.org/maven2"/>
+  <property name="ivy_bootstrap_url1" value="https://repo1.maven.org/maven2"/>
   <!-- you might need to tweak this from china so it works -->
-  <property name="ivy_bootstrap_url2" value="http://uk.maven.org/maven2"/>
+  <property name="ivy_bootstrap_url2" value="https://uk.maven.org/maven2"/>
   <property name="ivy_checksum_sha1" value="c5ebf1c253ad4959a29f4acfe696ee48cdd9f473"/>
 
   <target name="ivy-availability-check" unless="ivy.available">


### PR DESCRIPTION
Already had done this in the solr7-7-1 branch, but need to do it for master to set up weekly autobuilds. 