### PR TITLE
Prometheus to export cache stats

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -28,6 +28,7 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.common.MapSerializable;
 import org.apache.solr.core.SolrConfig;
+import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.util.DOMUtil;
 import org.slf4j.Logger;
@@ -49,7 +50,7 @@ public class CacheConfig implements MapSerializable{
   
   private String nodeName;
 
-  private Class<? extends SolrCache> clazz;
+//  private Class<? extends SolrCache> clazz;
   private Map<String,String> args;
   private CacheRegenerator regenerator;
 
@@ -62,7 +63,7 @@ public class CacheConfig implements MapSerializable{
   public CacheConfig() {}
 
   public CacheConfig(Class<? extends SolrCache> clazz, Map<String,String> args, CacheRegenerator regenerator) {
-    this.clazz = clazz;
+    this.cacheImpl = clazz.getName();
     this.args = args;
     this.regenerator = regenerator;
   }
@@ -126,7 +127,7 @@ public class CacheConfig implements MapSerializable{
     config.cacheImpl = config.args.get("class");
     if (config.cacheImpl == null) config.cacheImpl = "solr.CaffeineCache";
     config.regenImpl = config.args.get("regenerator");
-    config.clazz = loader.findClass(config.cacheImpl, SolrCache.class);
+//    config.clazz = loader.findClass(config.cacheImpl, SolrCache.class);
     if (config.regenImpl != null) {
       config.regenerator = loader.newInstance(config.regenImpl, CacheRegenerator.class);
     }
@@ -134,9 +135,9 @@ public class CacheConfig implements MapSerializable{
     return config;
   }
 
-  public SolrCache newInstance() {
+  public SolrCache newInstance(SolrCore core) {
     try {
-      SolrCache cache = clazz.getConstructor().newInstance();
+      SolrCache cache = SolrCore.createInstance(cacheImpl, SolrCache.class, null, core, core.getResourceLoader());
       persistence[0] = cache.init(args, persistence[0], regenerator);
       return cache;
     } catch (Exception e) {

--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -50,7 +50,6 @@ public class CacheConfig implements MapSerializable{
   
   private String nodeName;
 
-//  private Class<? extends SolrCache> clazz;
   private Map<String,String> args;
   private CacheRegenerator regenerator;
 
@@ -127,7 +126,6 @@ public class CacheConfig implements MapSerializable{
     config.cacheImpl = config.args.get("class");
     if (config.cacheImpl == null) config.cacheImpl = "solr.CaffeineCache";
     config.regenImpl = config.args.get("regenerator");
-//    config.clazz = loader.findClass(config.cacheImpl, SolrCache.class);
     if (config.regenImpl != null) {
       config.regenerator = loader.newInstance(config.regenImpl, CacheRegenerator.class);
     }

--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -360,6 +360,10 @@ public class CaffeineCache<K, V> extends SolrCacheBase implements SolrCache<K, V
     return metricNames;
   }
 
+  public Cache<K,V> getCache(){
+    return cache;
+  }
+
   @Override
   public void initializeMetrics(SolrMetricsContext parentContext, String scope) {
     solrMetricsContext = parentContext.getChildContext(this);

--- a/solr/core/src/java/org/apache/solr/search/SolrDocumentFetcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrDocumentFetcher.java
@@ -112,7 +112,7 @@ public class SolrDocumentFetcher {
     this.searcher = searcher;
     this.enableLazyFieldLoading = solrConfig.enableLazyFieldLoading;
     if (cachingEnabled) {
-      documentCache = solrConfig.documentCacheConfig == null ? null : solrConfig.documentCacheConfig.newInstance();
+      documentCache = solrConfig.documentCacheConfig == null ? null : solrConfig.documentCacheConfig.newInstance(searcher.getCore());
     } else {
       documentCache = null;
     }

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -272,12 +272,12 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     if (cachingEnabled) {
       final ArrayList<SolrCache> clist = new ArrayList<>();
       fieldValueCache = solrConfig.fieldValueCacheConfig == null ? null
-          : solrConfig.fieldValueCacheConfig.newInstance();
+          : solrConfig.fieldValueCacheConfig.newInstance(core);
       if (fieldValueCache != null) clist.add(fieldValueCache);
-      filterCache = solrConfig.filterCacheConfig == null ? null : solrConfig.filterCacheConfig.newInstance();
+      filterCache = solrConfig.filterCacheConfig == null ? null : solrConfig.filterCacheConfig.newInstance(core);
       if (filterCache != null) clist.add(filterCache);
       queryResultCache = solrConfig.queryResultCacheConfig == null ? null
-          : solrConfig.queryResultCacheConfig.newInstance();
+          : solrConfig.queryResultCacheConfig.newInstance(core);
       if (queryResultCache != null) clist.add(queryResultCache);
       SolrCache<Integer, Document> documentCache = docFetcher.getDocumentCache();
       if (documentCache != null) clist.add(documentCache);
@@ -287,7 +287,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       } else {
         cacheMap = new HashMap<>(solrConfig.userCacheConfigs.size());
         for (Map.Entry<String,CacheConfig> e : solrConfig.userCacheConfigs.entrySet()) {
-          SolrCache cache = e.getValue().newInstance();
+          SolrCache cache = e.getValue().newInstance(core);
           if (cache != null) {
             cacheMap.put(cache.name(), cache);
             clist.add(cache);

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -93,6 +93,9 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
   }
 
   private static void writeCacheMetrics(PrintWriter writer) {
+    if(SolrDispatchFilter.instance == null) {
+      return;
+    }
     Supplier<Map> supplier = (Supplier<Map>) SolrDispatchFilter.instance.cores.getZkController().getSolrCloudManager().getObjectCache().get("fs-shared-caches");
     if (supplier == null) {
       return;

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -96,7 +96,7 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     if(SolrDispatchFilter.instance == null) {
       return;
     }
-    Supplier<Map> supplier = (Supplier<Map>) SolrDispatchFilter.instance.cores.getZkController().getSolrCloudManager().getObjectCache().get("fs-shared-caches");
+    Supplier<Map> supplier = (Supplier<Map>) SolrDispatchFilter.instance.cores.getZkController().getSolrCloudManager().getObjectCache().get(SHARED_CACHE_METRIC_NAME);
     if (supplier == null) {
       return;
     }
@@ -116,4 +116,5 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
       });
     }
   }
+  public static final String SHARED_CACHE_METRIC_NAME =  "fs-shared-caches";
 }

--- a/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
@@ -113,8 +113,6 @@ public class SolrDispatchFilter extends BaseSolrFilter {
   private SolrMetricManager metricManager;
   private String registryName;
   private volatile boolean closeOnDestroy = true;
-  static volatile SolrDispatchFilter instance;
-
 
   /**
    * Enum to define action that needs to be processed.
@@ -127,7 +125,7 @@ public class SolrDispatchFilter extends BaseSolrFilter {
   public enum Action {
     PASSTHROUGH, FORWARD, RETURN, RETRY, ADMIN, REMOTEQUERY, PROCESS
   }
-  
+
   public SolrDispatchFilter() {
   }
 
@@ -198,9 +196,8 @@ public class SolrDispatchFilter extends BaseSolrFilter {
 
     }finally{
       log.trace("SolrDispatchFilter.init() done");
-      this.cores = coresInit; // crucially final assignment 
+      this.cores = coresInit; // crucially final assignment
       init.countDown();
-      instance = this;
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
@@ -113,6 +113,8 @@ public class SolrDispatchFilter extends BaseSolrFilter {
   private SolrMetricManager metricManager;
   private String registryName;
   private volatile boolean closeOnDestroy = true;
+  static SolrDispatchFilter instance;
+
 
   /**
    * Enum to define action that needs to be processed.
@@ -144,6 +146,7 @@ public class SolrDispatchFilter extends BaseSolrFilter {
   @Override
   public void init(FilterConfig config) throws ServletException
   {
+    instance = this;
     SSLConfigurationsFactory.current().init();
     log.trace("SolrDispatchFilter.init(): {}", this.getClass().getClassLoader());
     CoreContainer coresInit = null;

--- a/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
@@ -113,7 +113,7 @@ public class SolrDispatchFilter extends BaseSolrFilter {
   private SolrMetricManager metricManager;
   private String registryName;
   private volatile boolean closeOnDestroy = true;
-  static SolrDispatchFilter instance;
+  static volatile SolrDispatchFilter instance;
 
 
   /**
@@ -146,7 +146,6 @@ public class SolrDispatchFilter extends BaseSolrFilter {
   @Override
   public void init(FilterConfig config) throws ServletException
   {
-    instance = this;
     SSLConfigurationsFactory.current().init();
     log.trace("SolrDispatchFilter.init(): {}", this.getClass().getClassLoader());
     CoreContainer coresInit = null;
@@ -201,6 +200,7 @@ public class SolrDispatchFilter extends BaseSolrFilter {
       log.trace("SolrDispatchFilter.init() done");
       this.cores = coresInit; // crucially final assignment 
       init.countDown();
+      instance = this;
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
@@ -125,7 +125,7 @@ public class SolrDispatchFilter extends BaseSolrFilter {
   public enum Action {
     PASSTHROUGH, FORWARD, RETURN, RETRY, ADMIN, REMOTEQUERY, PROCESS
   }
-
+  
   public SolrDispatchFilter() {
   }
 
@@ -196,7 +196,7 @@ public class SolrDispatchFilter extends BaseSolrFilter {
 
     }finally{
       log.trace("SolrDispatchFilter.init() done");
-      this.cores = coresInit; // crucially final assignment
+      this.cores = coresInit; // crucially final assignment 
       init.countDown();
     }
   }

--- a/solr/core/src/test/org/apache/solr/servlet/PrometheusMetricsServletTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/PrometheusMetricsServletTest.java
@@ -18,11 +18,12 @@ package org.apache.solr.servlet;
 
 import java.io.PrintWriter;
 
+import org.apache.solr.core.CoreContainer;
 import org.junit.Test;
 
 public class PrometheusMetricsServletTest {
   @Test
   public void testWriteMetrics() throws Exception {
-    PrometheusMetricsServlet.writeStats(new PrintWriter(System.out));
+    PrometheusMetricsServlet.writeStats(new PrintWriter(System.out), null);
   }
 }


### PR DESCRIPTION
This makes the following changes
* `PrometheusServlet` shows cache stats
*  Caches now can have an optional constructor which accepts a `SolrCore` instance. This change is made to `CacheConfig`