### PR TITLE
LUCENE-9302,SOLR-14381: Integer overflow in total count in grouping results (7x/master)

### DIFF
--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/BlockGroupingCollector.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/BlockGroupingCollector.java
@@ -354,8 +354,8 @@ public class BlockGroupingCollector extends SimpleCollector {
 
     return new TopGroups<>(new TopGroups<>(groupSort.getSort(),
                                        withinGroupSort.getSort(),
-                                       totalHitCount, totalGroupedHitCount, groups, maxScore),
-                         totalGroupCount);
+                                      (long) totalHitCount, (long) totalGroupedHitCount, groups, maxScore),
+                          (long) totalGroupCount);
   }
 
   @Override

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/GroupingSearch.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/GroupingSearch.java
@@ -163,7 +163,7 @@ public class GroupingSearch {
     }
 
     if (allGroups) {
-      return new TopGroups(secondPassCollector.getTopGroups(groupDocsOffset), matchingGroups.size());
+      return new TopGroups(secondPassCollector.getTopGroups(groupDocsOffset), (long) matchingGroups.size());
     } else {
       return secondPassCollector.getTopGroups(groupDocsOffset);
     }

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroups.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroups.java
@@ -27,13 +27,13 @@ import org.apache.lucene.search.TopFieldDocs;
  * @lucene.experimental */
 public class TopGroups<T> {
   /** Number of documents matching the search */
-  public final int totalHitCount;
+  public final long totalHitCount;
 
   /** Number of documents grouped into the topN groups */
-  public final int totalGroupedHitCount;
+  public final long totalGroupedHitCount;
 
   /** The total number of unique groups. If <code>null</code> this value is not computed. */
-  public final Integer totalGroupCount;
+  public final Long totalGroupCount;
 
   /** Group results in groupSort order */
   public final GroupDocs<T>[] groups;
@@ -48,7 +48,7 @@ public class TopGroups<T> {
    *  <code>Float.NaN</code> if scores were not computed. */
   public final float maxScore;
 
-  public TopGroups(SortField[] groupSort, SortField[] withinGroupSort, int totalHitCount, int totalGroupedHitCount, GroupDocs<T>[] groups, float maxScore) {
+  public TopGroups(SortField[] groupSort, SortField[] withinGroupSort, long totalHitCount, long totalGroupedHitCount, GroupDocs<T>[] groups, float maxScore) {
     this.groupSort = groupSort;
     this.withinGroupSort = withinGroupSort;
     this.totalHitCount = totalHitCount;
@@ -58,7 +58,7 @@ public class TopGroups<T> {
     this.maxScore = maxScore;
   }
 
-  public TopGroups(TopGroups<T> oldTopGroups, Integer totalGroupCount) {
+  public TopGroups(TopGroups<T> oldTopGroups, Long totalGroupCount) {
     this.groupSort = oldTopGroups.groupSort;
     this.withinGroupSort = oldTopGroups.withinGroupSort;
     this.totalHitCount = oldTopGroups.totalHitCount;
@@ -103,10 +103,10 @@ public class TopGroups<T> {
       return null;
     }
 
-    int totalHitCount = 0;
-    int totalGroupedHitCount = 0;
+    long totalHitCount = 0;
+    long totalGroupedHitCount = 0;
     // Optionally merge the totalGroupCount.
-    Integer totalGroupCount = null;
+    Long totalGroupCount = null;
 
     final int numGroups = shardGroups[0].groups.length;
     for(TopGroups<T> shard : shardGroups) {
@@ -117,7 +117,7 @@ public class TopGroups<T> {
       totalGroupedHitCount += shard.totalGroupedHitCount;
       if (shard.totalGroupCount != null) {
         if (totalGroupCount == null) {
-          totalGroupCount = 0;
+          totalGroupCount = 0L;
         }
 
         totalGroupCount += shard.totalGroupCount;
@@ -139,7 +139,7 @@ public class TopGroups<T> {
       final T groupValue = shardGroups[0].groups[groupIDX].groupValue;
       //System.out.println("  merge groupValue=" + groupValue + " sortValues=" + Arrays.toString(shardGroups[0].groups[groupIDX].groupSortValues));
       float maxScore = Float.MIN_VALUE;
-      int totalHits = 0;
+      long totalHits = 0;
       double scoreSum = 0.0;
       for(int shardIDX=0;shardIDX<shardGroups.length;shardIDX++) {
         //System.out.println("    shard=" + shardIDX);

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
@@ -454,7 +454,7 @@ public class TestGrouping extends LuceneTestCase {
     final List<BytesRef> sortedGroups = new ArrayList<>();
     final List<Comparable<?>[]> sortedGroupFields = new ArrayList<>();
 
-    int totalHitCount = 0;
+    long totalHitCount = 0;
     Set<BytesRef> knownGroups = new HashSet<>();
 
     //System.out.println("TEST: slowGrouping");
@@ -496,7 +496,7 @@ public class TestGrouping extends LuceneTestCase {
     final Comparator<GroupDoc> docSortComp = getComparator(docSort);
     @SuppressWarnings({"unchecked","rawtypes"})
     final GroupDocs<BytesRef>[] result = new GroupDocs[limit-groupOffset];
-    int totalGroupedHitCount = 0;
+    long totalGroupedHitCount = 0;
     for(int idx=groupOffset;idx < limit;idx++) {
       final BytesRef group = sortedGroups.get(idx);
       final List<GroupDoc> docs = groups.get(group);
@@ -531,7 +531,7 @@ public class TestGrouping extends LuceneTestCase {
     if (doAllGroups) {
       return new TopGroups<>(
         new TopGroups<>(groupSort.getSort(), docSort.getSort(), totalHitCount, totalGroupedHitCount, result, Float.NaN),
-          knownGroups.size()
+          (long) knownGroups.size()
       );
     } else {
       return new TopGroups<>(groupSort.getSort(), docSort.getSort(), totalHitCount, totalGroupedHitCount, result, Float.NaN);
@@ -972,7 +972,7 @@ public class TestGrouping extends LuceneTestCase {
           
           if (doAllGroups) {
             TopGroups<BytesRef> tempTopGroups = getTopGroups(c2, docOffset);
-            groupsResult = new TopGroups<>(tempTopGroups, allGroupsCollector.getGroupCount());
+            groupsResult = new TopGroups<>(tempTopGroups, (long) allGroupsCollector.getGroupCount());
           } else {
             groupsResult = getTopGroups(c2, docOffset);
           }
@@ -1059,8 +1059,8 @@ public class TestGrouping extends LuceneTestCase {
         final TopGroups<BytesRef> tempTopGroupsBlocks = (TopGroups<BytesRef>) c3.getTopGroups(docSort, groupOffset, docOffset, docOffset+docsPerGroup, fillFields);
         final TopGroups<BytesRef> groupsResultBlocks;
         if (doAllGroups && tempTopGroupsBlocks != null) {
-          assertEquals((int) tempTopGroupsBlocks.totalGroupCount, allGroupsCollector2.getGroupCount());
-          groupsResultBlocks = new TopGroups<>(tempTopGroupsBlocks, allGroupsCollector2.getGroupCount());
+          assertEquals((long) tempTopGroupsBlocks.totalGroupCount, (long) allGroupsCollector2.getGroupCount());
+          groupsResultBlocks = new TopGroups<>(tempTopGroupsBlocks, (long) allGroupsCollector2.getGroupCount());
         } else {
           groupsResultBlocks = tempTopGroupsBlocks;
         }

--- a/solr/FULLSTORY-CHANGES.txt
+++ b/solr/FULLSTORY-CHANGES.txt
@@ -36,3 +36,4 @@
 * SOLR-14158: Package trusted keys to come from Package Store, not ZK (noble, Ishan Chattopadhyaya)
 * SOLR-14165: SolrResponse serialVersionUID has changed in a backward incompatible way (Andy Webb via noble)
 * LUCENE-9170: Fix https maven issues with wagon-ssh etc. (Ishan Chattopadhyaya)
+* LUCENE-9302, SOLR-14381: Grouping to use long instead of int to avoid overflows (Ishan Chattopadhyaya)

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -2558,6 +2558,9 @@ public final class SolrCore implements SolrInfoBean, SolrMetricProducer, Closeab
 
     preDecorateResponse(req, rsp);
 
+    if (req.getOriginalParams().get("group") != null) {
+      System.out.println("hello: "+req);
+    }
     /*
      * Keeping this usage of isDebugEnabled because the extraction of the log data as a string might be slow. TODO:
      * Determine how likely it is that something is going to go wrong that will prevent the logging at INFO further

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -2558,9 +2558,6 @@ public final class SolrCore implements SolrInfoBean, SolrMetricProducer, Closeab
 
     preDecorateResponse(req, rsp);
 
-    if (req.getOriginalParams().get("group") != null) {
-      System.out.println("hello: "+req);
-    }
     /*
      * Keeping this usage of isDebugEnabled because the extraction of the log data as a string might be slow. TODO:
      * Determine how likely it is that something is going to go wrong that will prevent the logging at INFO further

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -63,6 +63,7 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.StrUtils;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.BasicResultContext;
 import org.apache.solr.response.ResultContext;
@@ -1280,7 +1281,7 @@ public class QueryComponent extends SearchComponent
     SearchGroupsResultTransformer serializer = new SearchGroupsResultTransformer(searcher);
 
     rsp.add("firstPhase", commandHandler.processResult(result, serializer));
-    rsp.add("totalHitCount", commandHandler.getTotalHitCount());
+    rsp.add("totalHitCount", Utils.intIfNotOverflown(commandHandler.getTotalHitCount()));
     rb.setResult(result);
   }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
@@ -186,12 +186,12 @@ public class ResponseBuilder
 
   // Context fields for grouping
   public final Map<String, Collection<SearchGroup<BytesRef>>> mergedSearchGroups = new HashMap<>();
-  public final Map<String, Integer> mergedGroupCounts = new HashMap<>();
+  public final Map<String, Long> mergedGroupCounts = new HashMap<>();
   public final Map<String, Map<SearchGroup<BytesRef>, Set<String>>> searchGroupToShards = new HashMap<>();
   public final Map<String, TopGroups<BytesRef>> mergedTopGroups = new HashMap<>();
   public final Map<String, QueryCommandResult> mergedQueryCommandResults = new HashMap<>();
   public final Map<Object, SolrDocument> retrievedDocuments = new HashMap<>();
-  public int totalHitCount; // Hit count used when distributed grouping is performed.
+  public long totalHitCount; // Hit count used when distributed grouping is performed.
   // Used for timeAllowed parameter. First phase elapsed time is subtracted from the time allowed for the second phase.
   public int firstPhaseElapsedTime;
 

--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -341,7 +341,7 @@ public class SimpleFacets {
         .add(mainQueryFilter, Occur.FILTER)
         .build();
     searcher.search(filteredFacetQuery, collector);
-    return collector.getGroupCount();
+    return (int) collector.getGroupCount();
   }
 
   enum FacetMethod {

--- a/solr/core/src/java/org/apache/solr/search/Grouping.java
+++ b/solr/core/src/java/org/apache/solr/search/Grouping.java
@@ -60,6 +60,7 @@ import org.apache.lucene.util.mutable.MutableValue;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.FieldType;
 import org.apache.solr.schema.SchemaField;
@@ -104,7 +105,7 @@ public class Grouping {
   private Filter luceneFilter;
   private NamedList grouped = new SimpleOrderedMap();
   private Set<Integer> idSet = new LinkedHashSet<>();  // used for tracking unique docs when we need a doclist
-  private int maxMatches;  // max number of matches from any grouping command
+  private long maxMatches;  // max number of matches from any grouping command
   private float maxScore = Float.NaN;  // max score seen in any doclist
   private boolean signalCacheWarning = false;
   private TimeLimitingCollector timeLimitingCollector;
@@ -578,7 +579,7 @@ public class Grouping {
      *
      * @return the number of matches for this <code>Command</code>
      */
-    public abstract int getMatches();
+    public abstract long getMatches();
 
     /**
      * Returns the number of groups found for this <code>Command</code>.
@@ -586,7 +587,7 @@ public class Grouping {
      *
      * @return the number of groups found for this <code>Command</code>
      */
-    protected Integer getNumberOfGroups() {
+    protected Long getNumberOfGroups() {
       return null;
     }
 
@@ -594,11 +595,11 @@ public class Grouping {
       NamedList groupResult = new SimpleOrderedMap();
       grouped.add(key, groupResult);  // grouped={ key={
 
-      int matches = getMatches();
-      groupResult.add("matches", matches);
+      long matches = getMatches();
+      groupResult.add("matches", Utils.intIfNotOverflown(matches));
       if (totalCount == TotalCount.grouped) {
-        Integer totalNrOfGroups = getNumberOfGroups();
-        groupResult.add("ngroups", totalNrOfGroups == null ? Integer.valueOf(0) : totalNrOfGroups);
+        Long totalNrOfGroups = getNumberOfGroups();
+        groupResult.add("ngroups", Utils.intIfNotOverflown(totalNrOfGroups == null ? Long.valueOf(0) : totalNrOfGroups));
       }
       maxMatches = Math.max(maxMatches, matches);
       return groupResult;
@@ -812,7 +813,7 @@ public class Grouping {
     }
 
     @Override
-    public int getMatches() {
+    public long getMatches() {
       if (result == null && fallBackCollector == null) {
         return 0;
       }
@@ -821,8 +822,8 @@ public class Grouping {
     }
 
     @Override
-    protected Integer getNumberOfGroups() {
-      return allGroupsCollector == null ? null : allGroupsCollector.getGroupCount();
+    protected Long getNumberOfGroups() {
+      return allGroupsCollector == null ? null : (long) allGroupsCollector.getGroupCount();
     }
   }
 
@@ -872,7 +873,7 @@ public class Grouping {
     }
 
     @Override
-    public int getMatches() {
+    public long getMatches() {
       return collector.getMatches();
     }
   }
@@ -990,7 +991,7 @@ public class Grouping {
     }
 
     @Override
-    public int getMatches() {
+    public long getMatches() {
       if (result == null && fallBackCollector == null) {
         return 0;
       }
@@ -999,8 +1000,8 @@ public class Grouping {
     }
 
     @Override
-    protected Integer getNumberOfGroups() {
-      return allGroupsCollector == null ? null : allGroupsCollector.getGroupCount();
+    protected Long getNumberOfGroups() {
+      return allGroupsCollector == null ? null : (long) allGroupsCollector.getGroupCount();
     }
 
   }

--- a/solr/core/src/java/org/apache/solr/search/grouping/CommandHandler.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/CommandHandler.java
@@ -124,7 +124,7 @@ public class CommandHandler {
   private final boolean truncateGroups;
   private final boolean includeHitCount;
   private boolean partialResults = false;
-  private int totalHitCount;
+  private long totalHitCount;
 
   private DocSet docSet;
 
@@ -247,7 +247,7 @@ public class CommandHandler {
     }
   }
 
-  public int getTotalHitCount() {
+  public long getTotalHitCount() {
     return totalHitCount;
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/command/QueryCommandResult.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/command/QueryCommandResult.java
@@ -24,9 +24,9 @@ import org.apache.lucene.search.TopDocs;
 public class QueryCommandResult {
 
   private final TopDocs topDocs;
-  private final int matches;
+  private final long matches;
 
-  public QueryCommandResult(TopDocs topDocs, int matches) {
+  public QueryCommandResult(TopDocs topDocs, long matches) {
     this.topDocs = topDocs;
     this.matches = matches;
   }
@@ -35,7 +35,7 @@ public class QueryCommandResult {
     return topDocs;
   }
 
-  public int getMatches() {
+  public long getMatches() {
     return matches;
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/command/SearchGroupsFieldCommand.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/command/SearchGroupsFieldCommand.java
@@ -132,9 +132,9 @@ public class SearchGroupsFieldCommand implements Command<SearchGroupsFieldComman
     } else {
       topGroups = Collections.emptyList();
     }
-    final Integer groupCount;
+    final Long groupCount;
     if (allGroupsCollector != null) {
-      groupCount = allGroupsCollector.getGroupCount();
+      groupCount = (long) allGroupsCollector.getGroupCount();
     } else {
       groupCount = null;
     }

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/command/SearchGroupsFieldCommandResult.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/command/SearchGroupsFieldCommandResult.java
@@ -26,15 +26,15 @@ import org.apache.lucene.util.BytesRef;
  */
 public class SearchGroupsFieldCommandResult {
 
-  private final Integer groupCount;
+  private final Long groupCount;
   private final Collection<SearchGroup<BytesRef>> searchGroups;
 
-  public SearchGroupsFieldCommandResult(Integer groupCount, Collection<SearchGroup<BytesRef>> searchGroups) {
+  public SearchGroupsFieldCommandResult(Long groupCount, Collection<SearchGroup<BytesRef>> searchGroups) {
     this.groupCount = groupCount;
     this.searchGroups = searchGroups;
   }
 
-  public Integer getGroupCount() {
+  public Long getGroupCount() {
     return groupCount;
   }
 

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
@@ -67,7 +67,7 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
 
     SearchGroupsResultTransformer serializer = new SearchGroupsResultTransformer(rb.req.getSearcher());
     int maxElapsedTime = 0;
-    int hitCountDuringFirstPhase = 0;
+    long hitCountDuringFirstPhase = 0;
 
     NamedList<Object> shardInfo = null;
     if (rb.req.getParams().getBool(ShardParams.SHARDS_INFO, false)) {
@@ -89,7 +89,7 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
           t.printStackTrace(new PrintWriter(trace));
           nl.add("trace", trace.toString());
         } else {
-          nl.add("numFound", (Integer) srsp.getSolrResponse().getResponse().get("totalHitCount"));
+          nl.add("numFound", ((Number) srsp.getSolrResponse().getResponse().get("totalHitCount")).longValue());
         }
         if (srsp.getSolrResponse() != null) {
           nl.add("time", srsp.getSolrResponse().getElapsedTime());
@@ -112,11 +112,11 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
       for (String field : commandSearchGroups.keySet()) {
         final SearchGroupsFieldCommandResult firstPhaseCommandResult = result.get(field);
 
-        final Integer groupCount = firstPhaseCommandResult.getGroupCount();
+        final Long groupCount = firstPhaseCommandResult.getGroupCount();
         if (groupCount != null) {
-          Integer existingGroupCount = rb.mergedGroupCounts.get(field);
+          Long existingGroupCount = rb.mergedGroupCounts.get(field);
           // Assuming groups don't cross shard boundary...
-          rb.mergedGroupCounts.put(field, existingGroupCount != null ? Integer.valueOf(existingGroupCount + groupCount) : groupCount);
+          rb.mergedGroupCounts.put(field, existingGroupCount != null ? Long.valueOf(existingGroupCount + groupCount) : groupCount);
         }
 
         final Collection<SearchGroup<BytesRef>> searchGroups = firstPhaseCommandResult.getSearchGroups();
@@ -135,7 +135,7 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
           shards.add(srsp.getShard());
         }
       }
-      hitCountDuringFirstPhase += (Integer) srsp.getSolrResponse().getResponse().get("totalHitCount");
+      hitCountDuringFirstPhase += ((Number) srsp.getSolrResponse().getResponse().get("totalHitCount")).longValue();
     }
     rb.totalHitCount = hitCountDuringFirstPhase;
     rb.firstPhaseElapsedTime = maxElapsedTime;

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
@@ -101,7 +101,7 @@ public class SearchGroupsResultTransformer implements ShardResultTransformer<Lis
         }
       }
 
-      final Long groupCount = (Long) topGroupsAndGroupCount.get(GROUP_COUNT);
+      final Long groupCount = topGroupsAndGroupCount.get(GROUP_COUNT)==null? null: ((Number) topGroupsAndGroupCount.get(GROUP_COUNT)).longValue();
       result.put(command.getKey(), new SearchGroupsFieldCommandResult(groupCount, searchGroups));
     }
     return result;

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
@@ -57,7 +57,7 @@ public class SearchGroupsResultTransformer implements ShardResultTransformer<Lis
         if (searchGroups != null) {
           commandResult.add(TOP_GROUPS, serializeSearchGroup(searchGroups, fieldCommand));
         }
-        final Integer groupedCount = fieldCommandResult.getGroupCount();
+        final Long groupedCount = fieldCommandResult.getGroupCount();
         if (groupedCount != null) {
           commandResult.add(GROUP_COUNT, groupedCount);
         }
@@ -101,7 +101,7 @@ public class SearchGroupsResultTransformer implements ShardResultTransformer<Lis
         }
       }
 
-      final Integer groupCount = (Integer) topGroupsAndGroupCount.get(GROUP_COUNT);
+      final Long groupCount = (Long) topGroupsAndGroupCount.get(GROUP_COUNT);
       result.put(command.getKey(), new SearchGroupsFieldCommandResult(groupCount, searchGroups));
     }
     return result;

--- a/solr/core/src/java/org/apache/solr/search/grouping/endresulttransformer/GroupedEndResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/endresulttransformer/GroupedEndResultTransformer.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.schema.FieldType;
 import org.apache.solr.schema.SchemaField;
@@ -53,10 +54,10 @@ public class GroupedEndResultTransformer implements EndResultTransformer {
         @SuppressWarnings("unchecked")
         TopGroups<BytesRef> topGroups = (TopGroups<BytesRef>) value;
         NamedList<Object> command = new SimpleOrderedMap<>();
-        command.add("matches", rb.totalHitCount);
-        Integer totalGroupCount = rb.mergedGroupCounts.get(entry.getKey());
+        command.add("matches", Utils.intIfNotOverflown(rb.totalHitCount));
+        Long totalGroupCount = rb.mergedGroupCounts.get(entry.getKey());
         if (totalGroupCount != null) {
-          command.add("ngroups", totalGroupCount);
+          command.add("ngroups", Utils.intIfNotOverflown(totalGroupCount));
         }
 
         List<NamedList> groups = new ArrayList<>();
@@ -88,7 +89,7 @@ public class GroupedEndResultTransformer implements EndResultTransformer {
       } else if (QueryCommandResult.class.isInstance(value)) {
         QueryCommandResult queryCommandResult = (QueryCommandResult) value;
         NamedList<Object> command = new SimpleOrderedMap<>();
-        command.add("matches", queryCommandResult.getMatches());
+        command.add("matches", Utils.intIfNotOverflown(queryCommandResult.getMatches()));
         SolrDocumentList docList = new SolrDocumentList();
         docList.setNumFound(queryCommandResult.getTopDocs().totalHits);
         if (!Float.isNaN(queryCommandResult.getTopDocs().getMaxScore())) {

--- a/solr/core/src/java/org/apache/solr/search/grouping/endresulttransformer/SimpleEndResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/endresulttransformer/SimpleEndResultTransformer.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.component.ResponseBuilder;
 
 import java.util.Map;
@@ -41,9 +42,9 @@ public class SimpleEndResultTransformer implements EndResultTransformer {
         @SuppressWarnings("unchecked")
         TopGroups<BytesRef> topGroups = (TopGroups<BytesRef>) value;
         NamedList<Object> command = new SimpleOrderedMap<>();
-        command.add("matches", rb.totalHitCount);
+        command.add("matches", Utils.intIfNotOverflown(rb.totalHitCount));
         if (topGroups.totalGroupCount != null) {
-          command.add("ngroups", topGroups.totalGroupCount);
+          command.add("ngroups", Utils.intIfNotOverflown(topGroups.totalGroupCount));
         }
         SolrDocumentList docList = new SolrDocumentList();
         docList.setStart(rb.getGroupingSpec().getOffset());

--- a/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
@@ -262,8 +262,8 @@ public class TestDistributedGrouping extends BaseDistributedSearchTestCase {
     QueryResponse rsp = client.query(params);
     NamedList nl = (NamedList<?>) rsp.getResponse().get("grouped");
     nl = (NamedList<?>) nl.getVal(0);
-    int matches = (Integer) nl.getVal(0);
-    int groupCount = (Integer) nl.get("ngroups");
+    long matches = ((Number) nl.getVal(0)).longValue();
+    long groupCount = ((Number) nl.get("ngroups")).longValue();
     assertEquals(100 * shardsArr.length, matches);
     assertEquals(shardsArr.length, groupCount);
 

--- a/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
@@ -872,7 +872,7 @@ public class TestGroupingSearch extends SolrTestCaseJ4 {
   public static Object buildGroupedResult(IndexSchema schema, List<Grp> sortedGroups, int start, int rows, int group_offset, int group_limit, boolean includeNGroups) {
     Map<String,Object> result = new LinkedHashMap<>();
 
-    long matches = 0;
+    int matches = 0;
     for (Grp grp : sortedGroups) {
       matches += grp.docs.size();
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/GroupCommand.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/GroupCommand.java
@@ -45,8 +45,8 @@ public class GroupCommand implements Serializable {
 
   private final String _name;
   private final List<Group> _values = new ArrayList<>();
-  private final int _matches;
-  private final Integer _ngroups;
+  private final long _matches;
+  private final Long _ngroups;
 
   /**
    * Creates a GroupCommand instance
@@ -54,7 +54,7 @@ public class GroupCommand implements Serializable {
    * @param name    The name of this command
    * @param matches The total number of documents found for this command
    */
-  public GroupCommand(String name, int matches) {
+  public GroupCommand(String name, long matches) {
     _name = name;
     _matches = matches;
     _ngroups = null;
@@ -67,7 +67,7 @@ public class GroupCommand implements Serializable {
    * @param matches The total number of documents found for this command
    * @param nGroups The total number of groups found for this command.
    */
-  public GroupCommand(String name, int matches, int nGroups) {
+  public GroupCommand(String name, long matches, long nGroups) {
     _name = name;
     _matches = matches;
     _ngroups = nGroups;
@@ -106,7 +106,7 @@ public class GroupCommand implements Serializable {
    *
    * @return the total number of documents found for this command.
    */
-  public int getMatches() {
+  public long getMatches() {
     return _matches;
   }
 
@@ -117,7 +117,7 @@ public class GroupCommand implements Serializable {
    *
    * @return the total number of groups found for this command.
    */
-  public Integer getNGroups() {
+  public Long getNGroups() {
     return _ngroups;
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/response/QueryResponse.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/response/QueryResponse.java
@@ -266,11 +266,11 @@ public class QueryResponse extends SolrResponseBase
         }
 
         if (oGroups != null) {
-          Integer iMatches = (Integer) oMatches;
+          Long iMatches = oMatches==null? null: ((Number) oMatches).longValue();
           ArrayList<Object> groupsArr = (ArrayList<Object>) oGroups;
           GroupCommand groupedCommand;
           if (oNGroups != null) {
-            Integer iNGroups = (Integer) oNGroups;
+            Long iNGroups = oNGroups==null? null: ((Number) oNGroups).longValue();
             groupedCommand = new GroupCommand(fieldName, iMatches, iNGroups);
           } else {
             groupedCommand = new GroupCommand(fieldName, iMatches);
@@ -286,10 +286,10 @@ public class QueryResponse extends SolrResponseBase
 
           _groupResponse.add(groupedCommand);
         } else if (queryCommand != null) {
-          Integer iMatches = (Integer) oMatches;
+          Long iMatches = oMatches==null? null: ((Number) oMatches).longValue();
           GroupCommand groupCommand;
           if (oNGroups != null) {
-            Integer iNGroups = (Integer) oNGroups;
+            Long iNGroups = oMatches==null? null: ((Number) oNGroups).longValue();;
             groupCommand = new GroupCommand(fieldName, iMatches, iNGroups);
           } else {
             groupCommand = new GroupCommand(fieldName, iMatches);

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -203,6 +203,18 @@ public class Utils {
     return writer;
   }
 
+  /**
+   * Given long integer, return an integer or a long integer
+   * depending upon whether it overflows the integer range.
+   */
+  static public Number intIfNotOverflown(long n) {
+    if (((int) n) == n){
+      return Integer.valueOf((int)n);
+    } else {
+      return Long.valueOf(n);
+    }
+  }
+
   private static class MapWriterJSONWriter extends JSONWriter {
 
     public MapWriterJSONWriter(CharArr out, int indentSize) {


### PR DESCRIPTION
This is based on #54 (which is for 8x). This is part two of the grouping fix, meant to be merged to 7x/master. For reference, the previous (intermediate) fix was reviewed here: https://github.com/fullstorydev/lucene-solr/pull/55