### PR TITLE
Cache Plugin Loading: Use resolved plugin classpath

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -141,9 +141,9 @@ public class CacheConfig implements MapSerializable{
 
   public SolrCache newInstance(SolrCore core) {
     try {
-      SolrResourceLoader  resourceLoader = findResourceLoader(core,
-          new PluginInfo("cache", Utils.makeMap("class", cacheImpl)));
-      SolrCache cache = SolrCore.createInstance(cacheImpl, SolrCache.class, null, core,
+      PluginInfo info = new PluginInfo("cache", Utils.makeMap("class", cacheImpl));
+      SolrResourceLoader  resourceLoader = findResourceLoader(core, info);
+      SolrCache cache = SolrCore.createInstance(info.className, SolrCache.class, null, core,
           resourceLoader);
       persistence[0] = cache.init(args, persistence[0], regenerator);
       return cache;


### PR DESCRIPTION
Plugin class paths take the form of name space, like "xyz" and a class path "foo.bar.baz" which forms "xyz:foo.bar.baz". Plugin loading takes the previous string and breaks it apart into a package and classpath component. This updates cache instantiation to use the class path portion of the configured cache if it is present