### PR TITLE
Fixed: truncated large term text with length (>32766)

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/SortedDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortedDocValuesWriter.java
@@ -70,7 +70,7 @@ class SortedDocValuesWriter extends DocValuesWriter {
       throw new IllegalArgumentException("field \"" + fieldInfo.name + "\": null value not allowed");
     }
     if (value.length > (BYTE_BLOCK_SIZE - 2)) {
-      throw new IllegalArgumentException("DocValuesField \"" + fieldInfo.name + "\" is too large, must be <= " + (BYTE_BLOCK_SIZE - 2));
+      value = new BytesRef(value.bytes, 0, BYTE_BLOCK_SIZE - 2);
     }
 
     addOneValue(value);

--- a/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValuesWriter.java
@@ -79,7 +79,7 @@ class SortedSetDocValuesWriter extends DocValuesWriter {
       throw new IllegalArgumentException("field \"" + fieldInfo.name + "\": null value not allowed");
     }
     if (value.length > (BYTE_BLOCK_SIZE - 2)) {
-      throw new IllegalArgumentException("DocValuesField \"" + fieldInfo.name + "\" is too large, must be <= " + (BYTE_BLOCK_SIZE - 2));
+      value = new BytesRef(value.bytes, 0, BYTE_BLOCK_SIZE - 2);
     }
 
     if (docID != currentDoc) {

--- a/lucene/core/src/java/org/apache/lucene/index/TermsHashPerField.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermsHashPerField.java
@@ -23,9 +23,12 @@ import org.apache.lucene.analysis.tokenattributes.TermFrequencyAttribute;
 import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
 import org.apache.lucene.util.ByteBlockPool;
 import org.apache.lucene.util.BytesRefHash.BytesStartArray;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefHash;
 import org.apache.lucene.util.Counter;
 import org.apache.lucene.util.IntBlockPool;
+
+import static org.apache.lucene.util.ByteBlockPool.BYTE_BLOCK_SIZE;
 
 abstract class TermsHashPerField implements Comparable<TermsHashPerField> {
   private static final int HASH_INIT_SIZE = 4;
@@ -145,10 +148,16 @@ abstract class TermsHashPerField implements Comparable<TermsHashPerField> {
    *  entry point (for first TermsHash); postings use this
    *  API. */
   void add() throws IOException {
+    BytesRef bytesRef = termAtt.getBytesRef();
+
+    if(bytesRef.length > BYTE_BLOCK_SIZE - 2) {
+      bytesRef =  new BytesRef(termAtt.getBytesRef().bytes, 0, BYTE_BLOCK_SIZE - 2);
+    }
+
     // We are first in the chain so we must "intern" the
     // term text into textStart address
     // Get the text & hash of this term.
-    int termID = bytesHash.add(termAtt.getBytesRef());
+    int termID = bytesHash.add(bytesRef);
       
     //System.out.println("add term=" + termBytesRef.utf8ToString() + " doc=" + docState.docID + " termID=" + termID);
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocValuesIndexing.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocValuesIndexing.java
@@ -353,12 +353,10 @@ public class TestDocValuesIndexing extends LuceneTestCase {
     BytesRef b = new BytesRef(bytes);
     random().nextBytes(bytes);
     hugeDoc.add(new SortedDocValuesField("dv", b));
-    expectThrows(IllegalArgumentException.class, () -> {
-      iwriter.addDocument(hugeDoc);
-    });
+    iwriter.addDocument(hugeDoc);
 
     IndexReader ir = iwriter.getReader();
-    assertEquals(1, ir.numDocs());
+    assertEquals(2, ir.numDocs());
     ir.close();
     iwriter.close();
     directory.close();
@@ -381,12 +379,10 @@ public class TestDocValuesIndexing extends LuceneTestCase {
     BytesRef b = new BytesRef(bytes);
     random().nextBytes(bytes);
     hugeDoc.add(new SortedSetDocValuesField("dv", b));
-    expectThrows(IllegalArgumentException.class, () -> {
-      iwriter.addDocument(hugeDoc);
-    });
+    iwriter.addDocument(hugeDoc);
 
     IndexReader ir = iwriter.getReader();
-    assertEquals(1, ir.numDocs());
+    assertEquals(2, ir.numDocs());
     ir.close();
     iwriter.close();
     directory.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestExceedMaxTermLength.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExceedMaxTermLength.java
@@ -82,20 +82,7 @@ public class TestExceedMaxTermLength extends LuceneTestCase {
                           ft));
       }
       doc.add(f);
-      
-      IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
-        w.addDocument(doc);
-      });
-      String maxLengthMsg = String.valueOf(IndexWriter.MAX_TERM_LENGTH);
-      String msg = expected.getMessage();
-      assertTrue("IllegalArgumentException didn't mention 'immense term': " + msg,
-                 msg.contains("immense term"));
-      assertTrue("IllegalArgumentException didn't mention max length ("+maxLengthMsg+"): " + msg,
-                 msg.contains(maxLengthMsg));
-      assertTrue("IllegalArgumentException didn't mention field name ("+name+"): " + msg,
-                 msg.contains(name));
-      assertTrue("IllegalArgumentException didn't mention original message: " + msg,
-                 msg.contains("bytes can be at most") && msg.contains("in length; got"));
+      w.addDocument(doc);
     } finally {
       w.close();
     }

--- a/solr/core/src/test/org/apache/solr/update/TestExceedMaxTermLength.java
+++ b/solr/core/src/test/org/apache/solr/update/TestExceedMaxTermLength.java
@@ -69,7 +69,7 @@ public class TestExceedMaxTermLength extends SolrTestCaseJ4 {
       } else {
         doc = adoc("id", "1", longFieldName, longFieldValue);
       }
-      assertFailedU(doc);
+      assertU(doc);
     } else {
       //Use JSON
       try {
@@ -93,7 +93,7 @@ public class TestExceedMaxTermLength extends SolrTestCaseJ4 {
 
     assertU(commit());
 
-    assertQ(req("q", "*:*"), "//*[@numFound='0']");
+    assertQ(req("q", "*:*"), "//*[@numFound='1']");
   }
 
   @Test


### PR DESCRIPTION
Instead of throwing the exception when term text's length is large we
truncate the term.