### PR TITLE
processParams supports custom SearchComponent keys

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SearchComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchComponent.java
@@ -41,6 +41,7 @@ public abstract class SearchComponent implements SolrInfoBean, NamedListInitiali
    * The name given to this component in solrconfig.xml file
    */
   private String name = this.getClass().getName();
+  private String jsonKey;
 
   protected Set<String> metricNames = ConcurrentHashMap.newKeySet();
   protected MetricRegistry registry;
@@ -92,6 +93,9 @@ public abstract class SearchComponent implements SolrInfoBean, NamedListInitiali
     this.name = name;
   }
 
+  public String getJsonKey() { return this.jsonKey; }
+
+  public void setJsonKey(String key) { this.jsonKey = key; }
 
   //////////////////////// NamedListInitializedPlugin methods //////////////////////
   @Override

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchComponent.java
@@ -93,7 +93,8 @@ public abstract class SearchComponent implements SolrInfoBean, NamedListInitiali
   }
 
   /**
-   * Override getJsonKey for custom SearchComponents
+   * Built-in component json keys are explicitly handled in RequestUtil
+   * Override getJsonKey for custom SearchComponents so the custom json key can be parsed by RequestUtil
    */
   public String getJsonKey() { return null; }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchComponent.java
@@ -41,7 +41,6 @@ public abstract class SearchComponent implements SolrInfoBean, NamedListInitiali
    * The name given to this component in solrconfig.xml file
    */
   private String name = this.getClass().getName();
-  private String jsonKey;
 
   protected Set<String> metricNames = ConcurrentHashMap.newKeySet();
   protected MetricRegistry registry;
@@ -93,9 +92,10 @@ public abstract class SearchComponent implements SolrInfoBean, NamedListInitiali
     this.name = name;
   }
 
-  public String getJsonKey() { return this.jsonKey; }
-
-  public void setJsonKey(String key) { this.jsonKey = key; }
+  /**
+   * Override getJsonKey for custom SearchComponents
+   */
+  public String getJsonKey() { return null; }
 
   //////////////////////// NamedListInitializedPlugin methods //////////////////////
   @Override

--- a/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
+++ b/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
@@ -194,7 +194,7 @@ public class RequestUtil {
     }
 
     List<SearchComponent> components = ((SearchHandler) handler).getComponents();
-    Set<String> pluginNames = components.stream().map(c -> c.getJsonKey()).filter(c -> c != null).collect(Collectors.toSet());
+    Set<String> pluginJsonKeys = components.stream().map(c -> c.getJsonKey()).filter(c -> c != null).collect(Collectors.toSet());
 
     // implement compat for existing components...
     JsonQueryConverter jsonQueryConverter = new JsonQueryConverter();
@@ -220,7 +220,7 @@ public class RequestUtil {
           out = "rows";
         } else if (SORT.equals(key)) {
           out = SORT;
-        } else if ("params".equals(key) || "facet".equals(key) || pluginNames.contains(key) ) {
+        } else if ("params".equals(key) || "facet".equals(key) || pluginJsonKeys.contains(key) ) {
           // handled elsewhere
           continue;
         } else {

--- a/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
+++ b/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.solr.common.SolrException;
@@ -28,6 +30,7 @@ import org.apache.solr.common.params.MultiMapSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.ContentStream;
 import org.apache.solr.common.util.StrUtils;
+import org.apache.solr.handler.component.SearchComponent;
 import org.apache.solr.handler.component.SearchHandler;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestHandler;
@@ -190,6 +193,9 @@ public class RequestUtil {
       }
     }
 
+    List<SearchComponent> components = ((SearchHandler) handler).getComponents();
+    Set<String> pluginNames = components.stream().map(c -> c.getJsonKey()).filter(c -> c != null).collect(Collectors.toSet());
+
     // implement compat for existing components...
     JsonQueryConverter jsonQueryConverter = new JsonQueryConverter();
     if (json != null && !isShard) {
@@ -214,7 +220,7 @@ public class RequestUtil {
           out = "rows";
         } else if (SORT.equals(key)) {
           out = SORT;
-        } else if ("params".equals(key) || "facet".equals(key) ) {
+        } else if ("params".equals(key) || "facet".equals(key) || pluginNames.contains(key) ) {
           // handled elsewhere
           continue;
         } else {


### PR DESCRIPTION
processParams only allows built-in SearchComponent keys.  This adds support for custom SearchComponents in processParams.
