### PR TITLE
processParams supports custom SearchComponent keys

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SearchComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchComponent.java
@@ -92,6 +92,11 @@ public abstract class SearchComponent implements SolrInfoBean, NamedListInitiali
     this.name = name;
   }
 
+  /**
+   * Built-in component json keys are explicitly handled in RequestUtil
+   * Override getJsonKey for custom SearchComponents so the custom json key can be parsed by RequestUtil
+   */
+  public String getJsonKey() { return null; }
 
   //////////////////////// NamedListInitializedPlugin methods //////////////////////
   @Override

--- a/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
+++ b/solr/core/src/java/org/apache/solr/request/json/RequestUtil.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.solr.common.SolrException;
@@ -28,6 +30,7 @@ import org.apache.solr.common.params.MultiMapSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.ContentStream;
 import org.apache.solr.common.util.StrUtils;
+import org.apache.solr.handler.component.SearchComponent;
 import org.apache.solr.handler.component.SearchHandler;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestHandler;
@@ -190,6 +193,9 @@ public class RequestUtil {
       }
     }
 
+    List<SearchComponent> components = ((SearchHandler) handler).getComponents();
+    Set<String> pluginJsonKeys = components.stream().map(c -> c.getJsonKey()).filter(c -> c != null).collect(Collectors.toSet());
+
     // implement compat for existing components...
     JsonQueryConverter jsonQueryConverter = new JsonQueryConverter();
 
@@ -231,7 +237,7 @@ public class RequestUtil {
             throw new SolrException(SolrException.ErrorCode.BAD_REQUEST,
                 "Expected Map for 'queries', received " + queriesJsonObj);
           }
-        } else if ("params".equals(key) || "facet".equals(key) ) {
+        } else if ("params".equals(key) || "facet".equals(key) || pluginJsonKeys.contains(key) ) {
           // handled elsewhere
           continue;
         } else {


### PR DESCRIPTION
Cherry-pick of solr-8.4 commit 24bc4d0a123cd87a793f9003c7fcb7a16d2040c8 onto lucene-solr/8.8 branch.

I'm a bit confused because this has already been cherry-picked onto ishan/8.8?