### PR TITLE
Support for query aggregator node - merged

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -75,11 +75,13 @@ import org.apache.solr.cloud.autoscaling.AutoScalingHandler;
 import org.apache.solr.common.AlreadyClosedException;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
+import org.apache.solr.common.cloud.CloudCollectionsListener;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Replica.State;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.params.CoreAdminParams;
 import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.common.util.ObjectCache;
@@ -157,6 +159,8 @@ import static org.apache.solr.security.AuthenticationPlugin.AUTHENTICATION_PLUGI
  */
 public class CoreContainer {
 
+  public static final String SOLR_QUERY_AGGREGATOR = "SolrQueryAggregator";
+
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   final SolrCores solrCores = new SolrCores(this);
@@ -205,6 +209,8 @@ public class CoreContainer {
       new SolrNamedThreadFactory("coreContainerWorkExecutor"));
 
   private final OrderedExecutor replayUpdatesExecutor;
+
+  private final boolean isQueryAggregator = Boolean.getBoolean(SOLR_QUERY_AGGREGATOR);
 
   @SuppressWarnings({"rawtypes"})
   protected volatile LogWatcher logging = null;
@@ -371,6 +377,26 @@ public class CoreContainer {
     } catch (Exception e) {
       log.warn("Unable to create [{}].  Features requiring this directory may fail.", userFilesPath, e);
     }
+    log.info("Initialized core container as {}", isQueryAggregator ? "query aggregator" : "data node");
+  }
+
+  private void registerCollectionListener() {
+    getZkController().getZkStateReader().registerCloudCollectionsListener(new CloudCollectionsListener() {
+      @Override
+      public void onChange(Set<String> oldCollections, Set<String> newCollections) {
+        // if core is not in newCollections and it exists locally, we delete the core
+        for (SolrCore core : getCores()) {
+          if (!newCollections.contains(core.getName())) {
+            try {
+              log.info("unloading/deleting core {} ", core.getName());
+              unload(core.getName(), true, true, true);
+            } catch (Exception ex) {
+              log.warn("Unable to unlaod core " + core.getName(), ex);
+            }
+          }
+        }
+      }
+    });
   }
 
   @SuppressWarnings({"unchecked"})
@@ -906,6 +932,9 @@ public class CoreContainer {
       autoScalingHandler = new AutoScalingHandler(getZkController().getSolrCloudManager(), loader);
       containerHandlers.put(AutoScalingHandler.HANDLER_PATH, autoScalingHandler);
       autoScalingHandler.initializeMetrics(solrMetricsContext, AutoScalingHandler.HANDLER_PATH);
+      if (isQueryAggregator) {
+        registerCollectionListener();
+      }
     }
     // This is a bit redundant but these are two distinct concepts for all they're accomplished at the same time.
     status |= LOAD_COMPLETE | INITIAL_CORE_LOAD_COMPLETE;
@@ -1425,17 +1454,21 @@ public class CoreContainer {
     try {
       MDCLoggingContext.setCoreDescriptor(this, dcore);
       SolrIdentifierValidator.validateCoreName(dcore.getName());
-      if (zkSys.getZkController() != null) {
+      // We are not registering proxy core
+      if (!isQueryAggregator && zkSys.getZkController() != null) {
         zkSys.getZkController().preRegister(dcore, publishState);
       }
-
       ConfigSet coreConfig = coreConfigService.loadConfigSet(dcore);
       dcore.setConfigSetTrusted(coreConfig.isTrusted());
       if (log.isInfoEnabled()) {
         log.info("Creating SolrCore '{}' using configuration from {}, trusted={}", dcore.getName(), coreConfig.getName(), dcore.isConfigSetTrusted());
       }
       try {
-        core = new SolrCore(this, dcore, coreConfig);
+        if (isQueryAggregator) {
+          core = new SolrCoreProxy(this, dcore, coreConfig);
+        } else {
+          core = new SolrCore(this, dcore, coreConfig);
+        }
       } catch (SolrException e) {
         core = processCoreCreateException(e, dcore, coreConfig);
       }
@@ -1469,6 +1502,34 @@ public class CoreContainer {
       throw t;
     } finally {
       MDCLoggingContext.clear();
+    }
+  }
+
+  SolrCore createProxyCore(String collectionName) {
+    DocCollection collection = getCollection(collectionName);
+
+    if (collection == null) {
+      return null;
+    }
+
+    Map<String, String> coreProps = new HashMap<>();
+    coreProps.put(CoreAdminParams.CORE_NODE_NAME, this.getHostName());
+    coreProps.put(CoreAdminParams.COLLECTION, collection.getName());
+
+    CoreDescriptor ret = new CoreDescriptor(
+        collection.getName(),
+        Paths.get(this.getSolrHome() + "/" + collection.getName()),
+        coreProps, this.getContainerProperties(), this.getZkController());
+
+    try {
+      SolrCore solrCore = solrCores.waitAddPendingCoreOps(ret.getName());
+      if (solrCore == null) {
+        solrCore = createFromDescriptor(ret, false, false);
+      }
+      solrCore.open();
+      return solrCore;
+    } finally {
+      solrCores.removeFromPendingOps(ret.getName());
     }
   }
 
@@ -1735,7 +1796,7 @@ public class CoreContainer {
         }
 
 
-        if (docCollection != null) {
+        if (!isQueryAggregator && docCollection != null) {
           Replica replica = docCollection.getReplica(cd.getCloudDescriptor().getCoreNodeName());
           assert replica != null;
           if (replica.getType() == Replica.Type.TLOG) { // TODO: needed here?
@@ -1849,7 +1910,7 @@ public class CoreContainer {
     // delete metrics specific to this core
     metricManager.removeRegistry(core.getCoreMetricManager().getRegistryName());
 
-    if (zkSys.getZkController() != null) {
+    if (!isQueryAggregator && zkSys.getZkController() != null) {
       // cancel recovery in cloud mode
       core.getSolrCoreState().cancelRecovery();
       if (cd.getCloudDescriptor().getReplicaType() == Replica.Type.PULL
@@ -1863,7 +1924,7 @@ public class CoreContainer {
     if (close)
       core.closeAndWait();
 
-    if (zkSys.getZkController() != null) {
+    if (!isQueryAggregator && zkSys.getZkController() != null) {
       try {
         zkSys.getZkController().unregister(name, cd);
       } catch (InterruptedException e) {
@@ -1942,6 +2003,10 @@ public class CoreContainer {
     // If a core is loaded, we're done just return it.
     if (core != null) {
       return core;
+    }
+
+    if (isQueryAggregator) {
+      return createProxyCore(name);
     }
 
     // If it's not yet loaded, we can check if it's had a core init failure and "do the right thing"
@@ -2130,6 +2195,10 @@ public class CoreContainer {
     return solrCores.isCoreLoading(name);
   }
 
+  public boolean isQueryAggregator() {
+    return isQueryAggregator;
+  }
+
   public AuthorizationPlugin getAuthorizationPlugin() {
     return authorizationPlugin == null ? null : authorizationPlugin.plugin;
   }
@@ -2177,7 +2246,7 @@ public class CoreContainer {
     // Try to read the coreNodeName from the cluster state.
 
     String coreName = cd.getName();
-    DocCollection coll = getZkController().getZkStateReader().getClusterState().getCollection(cd.getCollectionName());
+    DocCollection coll = getCollection(cd.getConfigName());
     for (Replica rep : coll.getReplicas()) {
       if (coreName.equals(rep.getCoreName())) {
         log.warn("Core properties file for node {} found with no coreNodeName, attempting to repair with value {}. See SOLR-11503. {}"
@@ -2190,6 +2259,11 @@ public class CoreContainer {
     }
     log.error("Could not repair coreNodeName in core.properties file for core {}", coreName);
     return false;
+  }
+
+  private DocCollection getCollection(String collectionName) {
+    DocCollection coll = getZkController().getZkStateReader().getClusterState().getCollection(collectionName);
+    return coll;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/core/SolrCoreProxy.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCoreProxy.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.core;
+
+import org.apache.solr.update.UpdateHandler;
+
+public class SolrCoreProxy extends SolrCore {
+
+  public SolrCoreProxy(CoreContainer coreContainer, CoreDescriptor cd, ConfigSet coreConfig) {
+    super(coreContainer, cd, coreConfig);
+    registerCollectionWatcher();
+  }
+
+  public SolrCoreProxy(CoreContainer coreContainer, CoreDescriptor coreDescriptor, ConfigSet configSet,
+                       String dataDir, UpdateHandler updateHandler,
+                       IndexDeletionPolicyWrapper delPolicy, SolrCore prev, boolean reload) {
+    super(coreContainer, coreDescriptor, configSet, dataDir, updateHandler, delPolicy, prev, reload);
+    registerCollectionWatcher();
+  }
+
+  private void registerCollectionWatcher() {
+    //This will update the collection state, if there is shard split or move
+    if (getCoreContainer().isZooKeeperAware())
+      getCoreContainer().getZkController().getZkStateReader().registerDocCollectionWatcher(getName(), collection -> false);
+  }
+
+  protected void bufferUpdatesIfConstructing(CoreDescriptor coreDescriptor) {
+  }
+
+  /*
+  We register for config dir "configs/conf"; thus if user updates "configs/conf" then just reload proxycore.
+   */
+  protected boolean forceReloadCore() {
+    return true;
+  }
+}

--- a/solr/core/src/java/org/apache/solr/handler/admin/HealthCheckHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/HealthCheckHandler.java
@@ -110,8 +110,17 @@ public class HealthCheckHandler extends RequestHandlerBase {
       return;
     }
 
-    // Fail if not in live_nodes
-    if (!clusterState.getLiveNodes().contains(cores.getZkController().getNodeName())) {
+    boolean failed = false;
+    // Fail if not in live_nodes or query nodes
+    if (!cores.isQueryAggregator()
+        && !clusterState.getLiveNodes().contains(cores.getZkController().getNodeName())) {
+      failed = true;
+    } else if (cores.isQueryAggregator()
+        && !clusterState.getLiveQueryNodes().contains(cores.getZkController().getNodeName())) {
+      failed = true;
+    }
+
+    if (failed) {
       rsp.add(STATUS, FAILURE);
       rsp.setException(new SolrException(SolrException.ErrorCode.SERVICE_UNAVAILABLE, "Host Unavailable: Not in live nodes as per zk"));
       return;

--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -554,8 +554,9 @@ public class HttpSolrCall {
           HttpCacheHeaderUtil.setCacheControlHeader(config, resp, reqMethod);
           // unless we have been explicitly told not to, do cache validation
           // if we fail cache validation, execute the query
-          if (config.getHttpCachingConfig().isNever304() ||
-                  !HttpCacheHeaderUtil.doCacheHeaderValidation(solrReq, req, reqMethod, resp)) {
+          if (cores.isQueryAggregator() ||
+              config.getHttpCachingConfig().isNever304() ||
+              !HttpCacheHeaderUtil.doCacheHeaderValidation(solrReq, req, reqMethod, resp)) {
             SolrQueryResponse solrRsp = new SolrQueryResponse();
             /* even for HEAD requests, we need to execute the handler to
              * ensure we don't get an error (and to make sure the correct

--- a/solr/core/src/test/org/apache/solr/core/SolrCoreProxyTest.java
+++ b/solr/core/src/test/org/apache/solr/core/SolrCoreProxyTest.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.core;
+
+import java.util.Random;
+import java.util.Set;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.embedded.JettySolrRunner;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.cloud.AbstractFullDistribZkTestBase;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.cloud.ClusterState;
+import org.apache.solr.common.cloud.DocCollection;
+import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.util.NamedList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SolrCoreProxyTest extends AbstractFullDistribZkTestBase {
+
+  public SolrCoreProxyTest() {
+    sliceCount = 1;
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    System.setProperty(CoreContainer.SOLR_QUERY_AGGREGATOR, "true");
+    super.setUp();
+    createQueryNode();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    super.tearDown();
+    System.clearProperty(CoreContainer.SOLR_QUERY_AGGREGATOR);
+  }
+
+  @Test
+  @ShardsFixed(num = 1)
+  public void testCreateProxyCore() throws Exception {
+    String collectionName = "collection1";
+
+    CoreContainer queryNodeContainer = getQueryNodeContainer();
+    ClusterState clusterState = queryNodeContainer.getZkController().getClusterState();
+    Set<String> queryNodes = clusterState.getLiveQueryNodes();
+    Set<String> liveNodes = clusterState.getLiveNodes();
+
+    assertTrue("Expected one but found." + queryNodes.size(), queryNodes.size() == 1);
+    assertTrue("Query nodes should contain query node.", queryNodes.contains(queryNodeContainer.getZkController().getNodeName()));
+    assertTrue("There must be some live nodes.", liveNodes.size() > 0);
+    assertFalse("Query node should not register in live nodes.", liveNodes.contains(queryNodeContainer.getZkController().getNodeName()));
+
+
+    SolrCore core = queryNodeContainer.getCore(collectionName);
+
+    assertNotNull(core);
+    assertTrue(core instanceof SolrCoreProxy);
+
+    CoreDescriptor cd = core.getCoreDescriptor();
+    assertEquals(collectionName, cd.getCollectionName());
+
+    core.close();
+
+    String queryNodeUrl = null;
+    String ingestNodeUrl = null;
+    for (JettySolrRunner jetty : jettys) {
+      if (jetty.getCoreContainer().isQueryAggregator()) {
+        queryNodeUrl = jetty.getBaseUrl().toString();
+      } else {
+        ingestNodeUrl = jetty.getBaseUrl().toString();
+      }
+    }
+    assertNotNull(queryNodeUrl);
+    assertNotNull(ingestNodeUrl);
+
+    addDocs(ingestNodeUrl, collectionName, 10);
+    //query through query node
+    queryDocs(queryNodeUrl, collectionName, 10);
+
+    try {
+      System.setProperty("solr.test.sys.prop1", "propone");
+      System.setProperty("solr.test.sys.prop2", "proptwo");
+
+      verifyCoreReloadAfterSchemaConfigUpdate(collectionName);
+      verifyCollectionShards(collectionName);
+      verifyCollectionListenerInstalled(collectionName);
+      verifyDeleteCollection(collectionName);
+    } finally {
+      System.clearProperty("solr.test.sys.prop1");
+      System.clearProperty("solr.test.sys.prop2");
+    }
+  }
+
+  private void verifyCoreReloadAfterSchemaConfigUpdate(final String collection) throws Exception {
+    CoreContainer queryAggregatorContainer = getQueryNodeContainer();
+    SolrCore currentCore = queryAggregatorContainer.getCore(collection);
+    currentCore.close();
+
+    String update = "true";
+    //update conf1 directory
+    String zkConfigPath = "/configs/conf1";
+    zkServer.getZkClient().setData(zkConfigPath, update.getBytes(), true);
+
+    //now observe if unload happens.
+    Thread.sleep(10000);
+    SolrCore newCore = queryAggregatorContainer.getCore(collection);
+    newCore.close();
+    //core reference should be different
+    assertFalse(currentCore == newCore);
+  }
+
+  private void verifyCollectionShards(final String collection) throws Exception {
+    CoreContainer queryAggregatorContainer = getQueryNodeContainer();
+    ClusterState clusterState = queryAggregatorContainer.getZkController().getZkStateReader().getClusterState();
+    DocCollection docCollection = clusterState.getCollection(collection);
+
+    assertTrue("Collection should have one slice", docCollection.getActiveSlices().size() == 1);
+
+    CollectionAdminRequest.SplitShard splitShard = CollectionAdminRequest.splitShard(collection);
+    splitShard.setShardName("shard1");
+    NamedList<Object> response = splitShard.process(cloudClient).getResponse();
+    assertNotNull(response.get("success"));
+    Thread.sleep(5000);
+    clusterState = queryAggregatorContainer.getZkController().getZkStateReader().getClusterState();
+    docCollection = clusterState.getCollection(collection);
+    ClusterState.CollectionRef collectionRef = clusterState.getCollectionStates().get(collection);
+    assertNotNull(collectionRef);
+    assertFalse(collectionRef instanceof ZkStateReader.LazyCollectionRef);
+    assertTrue("Collection now should have two slices", docCollection.getActiveSlices().size() == 2);
+  }
+
+  private void verifyCollectionListenerInstalled(final String collection) throws Exception {
+    CoreContainer queryAggregatorContainer = getQueryNodeContainer();
+
+    assertTrue("There should be one collection watcher.",
+        queryAggregatorContainer.getZkController().getZkStateReader().getStateWatchers(collection).size() == 1);
+  }
+
+  private void verifyDeleteCollection(final String collection) throws Exception {
+    CollectionAdminRequest.Delete delete = CollectionAdminRequest.deleteCollection(collection);
+    NamedList<Object> response = delete.process(cloudClient).getResponse();
+    assertNotNull(response.get("success"));
+    Thread.sleep(10000);
+    CoreContainer queryAggregatorContainer = getQueryNodeContainer();
+    String corenames = "";
+
+    for (SolrCore core : queryAggregatorContainer.getCores()) {
+      corenames += core.getName() + " , ";
+    }
+    assertTrue("There should not be any core. " + corenames, queryAggregatorContainer.getCores().isEmpty());
+  }
+
+  private CoreContainer getQueryNodeContainer() {
+    CoreContainer queryAggregatorContainer = null;
+    for (JettySolrRunner jetty : jettys) {
+      if (jetty.getCoreContainer().isQueryAggregator()) {
+        queryAggregatorContainer = jetty.getCoreContainer();
+      }
+    }
+    assertNotNull("There should be one query node container", queryAggregatorContainer);
+    return queryAggregatorContainer;
+  }
+
+  private void addDocs(final String baseUrl, final String collection, int docs) throws Exception {
+    Random rd = new Random();
+    try (HttpSolrClient qclient = getHttpSolrClient(baseUrl)) {
+      for (int i = 1; i <= docs; i++) {
+        SolrInputDocument doc = new SolrInputDocument();
+        doc.addField("id", rd.nextInt());
+        qclient.add(collection, doc);
+        qclient.commit(collection);
+      }
+    }
+  }
+
+  private void queryDocs(final String baseUrl, final String collection, int docs) throws Exception {
+    SolrQuery query = new SolrQuery("*:*");
+    try (HttpSolrClient qclient = getHttpSolrClient(baseUrl)) {
+      QueryResponse results = qclient.query(collection, query);
+      assertEquals(docs, results.getResults().getNumFound());
+    }
+  }
+}

--- a/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
@@ -128,6 +128,19 @@ public class TestCoreContainer extends SolrTestCaseJ4 {
   }
 
   @Test
+  public void testProxyCore() throws Exception {
+    System.setProperty(CoreContainer.SOLR_QUERY_AGGREGATOR, "true");
+    CoreContainer cores = init(CONFIGSETS_SOLR_XML);
+    try {
+      SolrCore core = cores.create("core1", ImmutableMap.of("configSet", "minimal"));
+      assertTrue(core instanceof SolrCoreProxy);
+    } finally {
+      cores.shutdown();
+      System.clearProperty(CoreContainer.SOLR_QUERY_AGGREGATOR);
+    }
+  }
+
+  @Test
   public void testReloadSequential() throws Exception {
     final CoreContainer cc = init(CONFIGSETS_SOLR_XML);
     try {

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
@@ -51,13 +51,14 @@ public class ClusterState implements JSONWriter.Writable {
 
   private final Map<String, CollectionRef> collectionStates, immutableCollectionStates;
   private Set<String> liveNodes;
+  private Set<String> liveQueryNodes;
 
   /**
    * Use this constr when ClusterState is meant for consumption.
    */
   public ClusterState(Integer znodeVersion, Set<String> liveNodes,
       Map<String, DocCollection> collectionStates) {
-    this(liveNodes, getRefMap(collectionStates),znodeVersion);
+    this(liveNodes, Collections.emptySet(), getRefMap(collectionStates),znodeVersion);
   }
 
   private static Map<String, CollectionRef> getRefMap(Map<String, DocCollection> collectionStates) {
@@ -71,10 +72,12 @@ public class ClusterState implements JSONWriter.Writable {
 
   /**Use this if all the collection states are not readily available and some needs to be lazily loaded
    */
-  public ClusterState(Set<String> liveNodes, Map<String, CollectionRef> collectionStates, Integer znodeVersion){
+  public ClusterState(Set<String> liveNodes, Set<String> liveQueryNodes, Map<String, CollectionRef> collectionStates, Integer znodeVersion){
     this.znodeVersion = znodeVersion;
     this.liveNodes = new HashSet<>(liveNodes.size());
     this.liveNodes.addAll(liveNodes);
+    this.liveQueryNodes = new HashSet<>(liveQueryNodes.size());
+    this.liveQueryNodes.addAll(liveQueryNodes);
     this.collectionStates = new LinkedHashMap<>(collectionStates);
     this.immutableCollectionStates = Collections.unmodifiableMap(collectionStates);
   }
@@ -88,7 +91,7 @@ public class ClusterState implements JSONWriter.Writable {
    * @return the updated cluster state which preserves the current live nodes and zk node version
    */
   public ClusterState copyWith(String collectionName, DocCollection collection) {
-    ClusterState result = new ClusterState(liveNodes, new LinkedHashMap<>(collectionStates), znodeVersion);
+    ClusterState result = new ClusterState(liveNodes, liveQueryNodes, new LinkedHashMap<>(collectionStates), znodeVersion);
     if (collection == null) {
       result.collectionStates.remove(collectionName);
     } else {
@@ -120,7 +123,7 @@ public class ClusterState implements JSONWriter.Writable {
    */
   public DocCollection getCollection(String collection) {
     DocCollection coll = getCollectionOrNull(collection);
-    if (coll == null) throw new SolrException(ErrorCode.BAD_REQUEST, "Could not find collection : " + collection);
+    if (coll == null) throw new SolrException(ErrorCode.NOT_FOUND, "Could not find collection : " + collection);
     return coll;
   }
 
@@ -177,6 +180,10 @@ public class ClusterState implements JSONWriter.Writable {
    */
   public Set<String> getLiveNodes() {
     return Collections.unmodifiableSet(liveNodes);
+  }
+
+  public Set<String> getLiveQueryNodes() {
+    return Collections.unmodifiableSet(liveQueryNodes);
   }
 
   public String getShardId(String nodeName, String coreName) {
@@ -255,7 +262,7 @@ public class ClusterState implements JSONWriter.Writable {
       collections.put(collectionName, new CollectionRef(coll));
     }
 
-    return new ClusterState( liveNodes, collections,version);
+    return new ClusterState( liveNodes, Collections.emptySet(), collections, version);
   }
 
   // TODO move to static DocCollection.loadFromMap
@@ -359,6 +366,10 @@ public class ClusterState implements JSONWriter.Writable {
    */
   void setLiveNodes(Set<String> liveNodes){
     this.liveNodes = liveNodes;
+  }
+
+  void setLiveQueryNodes(Set<String> liveQueryNodes){
+    this.liveQueryNodes = liveQueryNodes;
   }
 
   /** Be aware that this may return collections which may not exist now.


### PR DESCRIPTION
* Added SolrCoreProxy class which extends SolrCore class.
1. Created SolrCoreProxy class to keep proxy for collection.
2. Added java system property "SolrQueryAggregator" to initialize solr
node as query aggregator node.
3. if property is there we create SolrCoreProxy instance for executing
query on solr node.
4. We set data "{"QueryAggregator": "true"}" for zk livenodes. That helps
to know query aggregator nodes.

5. Added support to delete the proxy collection and update coll state
a. Added watch for "collections' zknode to delete the proxy colllection
b. added watch for "collections/xyzcoll" to update the state of collections
c. added tests for it.

*6.Added support to reload proxy core. SolrCore registeres the "/solr/configs/FS4"
znode, thus any update to that node will trigger the watch. In that listener
it reloads the core. By default proxy core will force the core reload