### PR TITLE
added distributed call stats.

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -325,7 +325,7 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
   static class CoresMetricsApiCaller extends MetricsApiCaller {
 
     CoresMetricsApiCaller() {
-      super("core", "INDEX.merge.,QUERY./get.local.requestTimes,QUERY./select.local.requestTimes,UPDATE./update.local.requestTimes,UPDATE.updateHandler.autoCommits,UPDATE.updateHandler.commits,UPDATE.updateHandler.cumulativeDeletesBy,UPDATE.updateHandler.softAutoCommits", "count");
+      super("core", "INDEX.merge.,QUERY./get.distrib.requestTimes,QUERY./get.local.requestTimes,QUERY./select.distrib.requestTimes,QUERY./select.local.requestTimes,UPDATE./update.distrib.requestTimes,UPDATE./update.local.requestTimes,UPDATE.updateHandler.autoCommits,UPDATE.updateHandler.commits,UPDATE.updateHandler.cumulativeDeletesBy,UPDATE.updateHandler.softAutoCommits", "count");
     }
 
     /*
@@ -340,8 +340,11 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
       "INDEX.merge.minor.running":0,
       "INDEX.merge.minor.running.docs":0,
       "INDEX.merge.minor.running.segments":0,
+      "QUERY./get.distrib.requestTimes":{"count":0},
       "QUERY./get.local.requestTimes":{"count":0},
+      "QUERY./select.distrib.requestTimes":{"count":2},
       "QUERY./select.local.requestTimes":{"count":0},
+      "UPDATE./update.distrib.requestTimes":{"count":0},
       "UPDATE./update.local.requestTimes":{"count":0},
       "UPDATE.updateHandler.autoCommits":0,
       "UPDATE.updateHandler.commits":{"count":14877},
@@ -356,9 +359,12 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
       long mergeMajorDocs = 0;
       long mergeMinor = 0;
       long mergeMinorDocs = 0;
-      long get = 0;
-      long select = 0;
-      long update = 0;
+      long distribGet = 0;
+      long localGet = 0;
+      long distribSelect = 0;
+      long localSelect = 0;
+      long distribUpdate = 0;
+      long localUpdate = 0;
       long hardAutoCommit = 0;
       long commit = 0;
       long deleteById = 0;
@@ -369,9 +375,12 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         mergeMajorDocs += getNumber(core, "INDEX.merge.major.running.docs").longValue();
         mergeMinor += getNumber(core, "INDEX.merge.minor", property).longValue();
         mergeMinorDocs += getNumber(core, "INDEX.merge.minor.running.docs").longValue();
-        get += getNumber(core, "QUERY./get.local.requestTimes", property).longValue();
-        select += getNumber(core, "QUERY./select.local.requestTimes", property).longValue();
-        update += getNumber(core, "UPDATE./update.local.requestTimes", property).longValue();
+        distribGet += getNumber(core, "QUERY./get.distrib.requestTimes", property).longValue();
+        localGet += getNumber(core, "QUERY./get.local.requestTimes", property).longValue();
+        distribSelect += getNumber(core, "QUERY./select.distrib.requestTimes", property).longValue();
+        localSelect += getNumber(core, "QUERY./select.local.requestTimes", property).longValue();
+        distribUpdate += getNumber(core, "UPDATE./update.distrib.requestTimes", property).longValue();
+        localUpdate += getNumber(core, "UPDATE./update.local.requestTimes", property).longValue();
         hardAutoCommit += getNumber(core, "UPDATE.updateHandler.autoCommits").longValue();
         commit += getNumber(core, "UPDATE.updateHandler.commits", property).longValue();
         deleteById += getNumber(core, "UPDATE.updateHandler.cumulativeDeletesById", property).longValue();
@@ -382,9 +391,12 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
       results.add(new PrometheusMetric("merges_major_current_docs", PrometheusMetricType.GAUGE, "current number of docs in major merges across cores", mergeMajorDocs));
       results.add(new PrometheusMetric("merges_minor", PrometheusMetricType.COUNTER, "cumulative number of minor merges across cores", mergeMinor));
       results.add(new PrometheusMetric("merges_minor_current_docs", PrometheusMetricType.GAUGE, "current number of docs in minor merges across cores", mergeMinorDocs));
-      results.add(new PrometheusMetric("local_requests_get", PrometheusMetricType.COUNTER, "cumulative number of local gets across cores", get));
-      results.add(new PrometheusMetric("local_requests_select", PrometheusMetricType.COUNTER, "cumulative number of local selects across cores", select));
-      results.add(new PrometheusMetric("local_requests_update", PrometheusMetricType.COUNTER, "cumulative number of local updates across cores", update));
+      results.add(new PrometheusMetric("distributed_requests_get", PrometheusMetricType.COUNTER, "cumulative number of distributed gets across cores", distribGet));
+      results.add(new PrometheusMetric("local_requests_get", PrometheusMetricType.COUNTER, "cumulative number of local gets across cores", localGet));
+      results.add(new PrometheusMetric("distributed_requests_select", PrometheusMetricType.COUNTER, "cumulative number of distributed selects across cores", distribSelect));
+      results.add(new PrometheusMetric("local_requests_select", PrometheusMetricType.COUNTER, "cumulative number of local selects across cores", localSelect));
+      results.add(new PrometheusMetric("distributed_requests_update", PrometheusMetricType.COUNTER, "cumulative number of distributed updates across cores", distribUpdate));
+      results.add(new PrometheusMetric("local_requests_update", PrometheusMetricType.COUNTER, "cumulative number of local updates across cores", localUpdate));
       results.add(new PrometheusMetric("auto_commits_hard", PrometheusMetricType.COUNTER, "cumulative number of hard auto commits across cores", hardAutoCommit));
       results.add(new PrometheusMetric("auto_commits_soft", PrometheusMetricType.COUNTER, "cumulative number of soft auto commits across cores", softAutoCommit));
       results.add(new PrometheusMetric("commits", PrometheusMetricType.COUNTER, "cumulative number of commits across cores", commit));
@@ -456,7 +468,7 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     if (node.isNumber()) {
       return node.numberValue();
     } else {
-      LOGGER.error("node {} does not have a number at the path {}.", originalNode, Arrays.toString(names));
+      LOGGER.warn("node {} does not have a number at the path {}.", originalNode, Arrays.toString(names));
       return INVALID_NUMBER;
     }
   }

--- a/solr/core/src/test/org/apache/solr/servlet/PrometheusMetricsServletTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/PrometheusMetricsServletTest.java
@@ -281,8 +281,11 @@ public class PrometheusMetricsServletTest {
         "      \"INDEX.merge.minor.running\":7,\n" +
         "      \"INDEX.merge.minor.running.docs\":8,\n" +
         "      \"INDEX.merge.minor.running.segments\":9,\n" +
+        "      \"QUERY./get.distrib.requestTimes\":{\"count\":35},\n" +
         "      \"QUERY./get.local.requestTimes\":{\"count\":10},\n" +
+        "      \"QUERY./select.distrib.requestTimes\":{\"count\":36},\n" +
         "      \"QUERY./select.local.requestTimes\":{\"count\":11},\n" +
+        "      \"UPDATE./update.distrib.requestTimes\":{\"count\":37},\n" +
         "      \"UPDATE./update.local.requestTimes\":{\"count\":12},\n" +
         "      \"UPDATE.updateHandler.autoCommits\":13,\n" +
         "      \"UPDATE.updateHandler.commits\":{\"count\":33}," +
@@ -299,8 +302,11 @@ public class PrometheusMetricsServletTest {
         "      \"INDEX.merge.minor.running\":23,\n" +
         "      \"INDEX.merge.minor.running.docs\":24,\n" +
         "      \"INDEX.merge.minor.running.segments\":25,\n" +
+        "      \"QUERY./get.distrib.requestTimes\":{\"count\":38},\n" +
         "      \"QUERY./get.local.requestTimes\":{\"count\":26},\n" +
+        "      \"QUERY./select.distrib.requestTimes\":{\"count\":39},\n" +
         "      \"QUERY./select.local.requestTimes\":{\"count\":27},\n" +
+        "      \"UPDATE./update.distrib.requestTimes\":{\"count\":40},\n" +
         "      \"UPDATE./update.local.requestTimes\":{\"count\":28},\n" +
         "      \"UPDATE.updateHandler.autoCommits\":29,\n" +
         "      \"UPDATE.updateHandler.commits\":{\"count\":34}," +
@@ -319,12 +325,21 @@ public class PrometheusMetricsServletTest {
         "# HELP merges_minor_current_docs current number of docs in minor merges across cores\n" +
         "# TYPE merges_minor_current_docs gauge\n" +
         "merges_minor_current_docs 32\n" +
+        "# HELP distributed_requests_get cumulative number of distributed gets across cores\n" +
+        "# TYPE distributed_requests_get counter\n" +
+        "distributed_requests_get 73\n" +
         "# HELP local_requests_get cumulative number of local gets across cores\n" +
         "# TYPE local_requests_get counter\n" +
         "local_requests_get 36\n" +
+        "# HELP distributed_requests_select cumulative number of distributed selects across cores\n" +
+        "# TYPE distributed_requests_select counter\n" +
+        "distributed_requests_select 75\n" +
         "# HELP local_requests_select cumulative number of local selects across cores\n" +
         "# TYPE local_requests_select counter\n" +
         "local_requests_select 38\n" +
+        "# HELP distributed_requests_update cumulative number of distributed updates across cores\n" +
+        "# TYPE distributed_requests_update counter\n" +
+        "distributed_requests_update 77\n" +
         "# HELP local_requests_update cumulative number of local updates across cores\n" +
         "# TYPE local_requests_update counter\n" +
         "local_requests_update 40\n" +
@@ -354,32 +369,44 @@ public class PrometheusMetricsServletTest {
         "    \"QTime\":25},\n" +
         "  \"metrics\":{\n" +
         "    \"solr.core.loadtest.shard1_1.replica_n8\":{\n" +
+        "      \"QUERY./get.distrib.requestTimes\":{\"count\":29},\n" +
         "      \"QUERY./get.local.requestTimes\":{\"count\":1},\n" +
+        "      \"QUERY./select.distrib.requestTimes\":{\"count\":30},\n" +
         "      \"QUERY./select.local.requestTimes\":{\"count\":2},\n" +
+        "      \"UPDATE./update.distrib.requestTimes\":{\"count\":31},\n" +
         "      \"UPDATE./update.local.requestTimes\":{\"count\":3},\n" +
         "      \"UPDATE.updateHandler.autoCommits\":4,\n" +
         "      \"UPDATE.updateHandler.cumulativeDeletesById\":{\"count\":5},\n" +
         "      \"UPDATE.updateHandler.cumulativeDeletesByQuery\":{\"count\":6},\n" +
         "      \"UPDATE.updateHandler.softAutoCommits\":7},\n" +
         "    \"solr.core.testdrive.shard1.replica_n1\":{\n" +
+        "      \"QUERY./get.distrib.requestTimes\":{\"count\":32},\n" +
         "      \"QUERY./get.local.requestTimes\":{\"count\":8},\n" +
+        "      \"QUERY./select.distrib.requestTimes\":{\"count\":33},\n" +
         "      \"QUERY./select.local.requestTimes\":{\"count\":9},\n" +
+        "      \"UPDATE./update.distrib.requestTimes\":{\"count\":34},\n" +
         "      \"UPDATE./update.local.requestTimes\":{\"count\":10},\n" +
         "      \"UPDATE.updateHandler.autoCommits\":11,\n" +
         "      \"UPDATE.updateHandler.cumulativeDeletesById\":{\"count\":12},\n" +
         "      \"UPDATE.updateHandler.cumulativeDeletesByQuery\":{\"count\":13},\n" +
         "      \"UPDATE.updateHandler.softAutoCommits\":14},\n" +
         "    \"solr.core.loadtest.shard1_0.replica_n7\":{\n" +
+        "      \"QUERY./get.distrib.requestTimes\":{\"count\":35},\n" +
         "      \"QUERY./get.local.requestTimes\":{\"count\":15},\n" +
+        "      \"QUERY./select.distrib.requestTimes\":{\"count\":36},\n" +
         "      \"QUERY./select.local.requestTimes\":{\"count\":16},\n" +
+        "      \"UPDATE./update.distrib.requestTimes\":{\"count\":37},\n" +
         "      \"UPDATE./update.local.requestTimes\":{\"count\":17},\n" +
         "      \"UPDATE.updateHandler.autoCommits\":18,\n" +
         "      \"UPDATE.updateHandler.cumulativeDeletesById\":{\"count\":19},\n" +
         "      \"UPDATE.updateHandler.cumulativeDeletesByQuery\":{\"count\":20},\n" +
         "      \"UPDATE.updateHandler.softAutoCommits\":21},\n" +
         "    \"solr.core.local.shard1.replica_n1\":{\n" +
+        "      \"QUERY./get.distrib.requestTimes\":{\"count\":38},\n" +
         "      \"QUERY./get.local.requestTimes\":{\"count\":22},\n" +
+        "      \"QUERY./select.distrib.requestTimes\":{\"count\":39},\n" +
         "      \"QUERY./select.local.requestTimes\":{\"count\":23},\n" +
+        "      \"UPDATE./update.distrib.requestTimes\":{\"count\":40},\n" +
         "      \"UPDATE./update.local.requestTimes\":{\"count\":24},\n" +
         "      \"UPDATE.updateHandler.autoCommits\":25,\n" +
         "      \"UPDATE.updateHandler.cumulativeDeletesById\":{\"count\":26},\n" +
@@ -397,12 +424,21 @@ public class PrometheusMetricsServletTest {
         "# HELP merges_minor_current_docs current number of docs in minor merges across cores\n" +
         "# TYPE merges_minor_current_docs gauge\n" +
         "merges_minor_current_docs -4\n" +
+        "# HELP distributed_requests_get cumulative number of distributed gets across cores\n" +
+        "# TYPE distributed_requests_get counter\n" +
+        "distributed_requests_get 134\n" +
         "# HELP local_requests_get cumulative number of local gets across cores\n" +
         "# TYPE local_requests_get counter\n" +
         "local_requests_get 46\n" +
+        "# HELP distributed_requests_select cumulative number of distributed selects across cores\n" +
+        "# TYPE distributed_requests_select counter\n" +
+        "distributed_requests_select 138\n" +
         "# HELP local_requests_select cumulative number of local selects across cores\n" +
         "# TYPE local_requests_select counter\n" +
         "local_requests_select 50\n" +
+        "# HELP distributed_requests_update cumulative number of distributed updates across cores\n" +
+        "# TYPE distributed_requests_update counter\n" +
+        "distributed_requests_update 142\n" +
         "# HELP local_requests_update cumulative number of local updates across cores\n" +
         "# TYPE local_requests_update counter\n" +
         "local_requests_update 54\n" +


### PR DESCRIPTION
Previously we only had local get/select/update stats, but solr query aggregator only does distributed calls, so adding the distributed call stats.