### PR TITLE
Keep pool of singelthreaded-pool to create new searcher for SolrCoreProxy

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -186,7 +186,7 @@ public class SolrCore implements SolrInfoBean, SolrMetricProducer, Closeable {
 
   public static final String version = "1.0";
 
-  protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final Logger requestLog = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getName() + ".Request");
   private static final Logger slowLog = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getName() + ".SlowRequest");
 

--- a/solr/core/src/java/org/apache/solr/core/SolrCoreProxy.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCoreProxy.java
@@ -17,6 +17,7 @@
 
 package org.apache.solr.core;
 
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -25,9 +26,12 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.update.UpdateHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SolrCoreProxy extends SolrCore {
 
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   //to wait during core close
   private Future searcherExecutorFuture = null;
   private boolean isSearchExecutorClosed = false;

--- a/solr/core/src/java/org/apache/solr/core/SolrCoreProxy.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCoreProxy.java
@@ -17,11 +17,20 @@
 
 package org.apache.solr.core;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.update.UpdateHandler;
 
 public class SolrCoreProxy extends SolrCore {
+
+  //to wait during core close
+  private Future searcherExecutorFuture = null;
+  private boolean isSearchExecutorClosed = false;
 
   public SolrCoreProxy(CoreContainer coreContainer, CoreDescriptor cd, ConfigSet coreConfig) {
     super(coreContainer, cd, coreConfig);
@@ -50,5 +59,40 @@ public class SolrCoreProxy extends SolrCore {
    */
   protected boolean forceReloadCore() {
     return true;
+  }
+
+  protected ExecutorService getExecutorService(CoreContainer coreContainer, String name) {
+    //using executor from pool
+    final ExecutorService searcherExecutor;
+    searcherExecutor = coreContainer.getSearchExecutor(name + System.nanoTime());
+    return searcherExecutor;
+  }
+
+  protected void searchExecutorWaiter(Future future) {
+    searcherExecutorFuture = future;
+  }
+
+  protected void searchExecutorClosed() {
+    if (isSearchExecutorClosed) {
+      //caller should take care of it
+      throw new RuntimeException("Core has been closed");
+    }
+  }
+
+  protected void closeSearchExecutor() {
+    try {
+      openSearcherLock.lock();
+      if (searcherExecutor != null) {
+        searcherExecutorFuture.get(60, TimeUnit.SECONDS);
+      }
+    } catch (Throwable e) {
+      SolrException.log(log, e);
+      if (e instanceof Error) {
+        throw (Error) e;
+      }
+    } finally {
+      isSearchExecutorClosed = true;
+      openSearcherLock.unlock();
+    }
   }
 }


### PR DESCRIPTION
1. Solr core creates new searcher using single thread, which has few sequential steps
2. for that, SolrCore has single threaded-pool per instance
3. Solr query aggregator refers 1000s of cores.
4. thus it end up creating 1000s of threads
5. Thus now we have pool of single-thread-pool for those proxy collections
6. added system property 'SolrCoreSearchExecutors' for that, default 113
7. This optimization is not done for SolrCore, as it was creating deadlock between "commit" and "core-reload" thread
8. SolrCoreProxy doesn't have update commit.
