### PR TITLE
Updated query qggregator node for overseer, reconnect and config listener

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -985,7 +985,7 @@ public class CoreContainer {
   public void shutdown() {
 
     ZkController zkController = getZkController();
-    if (zkController != null) {
+    if (!isQueryAggregator() && zkController != null) {
       OverseerTaskQueue overseerCollectionQueue = zkController.getOverseerCollectionQueue();
       overseerCollectionQueue.allowOverseerPendingTasksToComplete();
     }

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -3072,7 +3072,7 @@ public class SolrCore implements SolrInfoBean, SolrMetricProducer, Closeable {
    * there is no event fired when children are modified. So , we expect everyone
    * to 'touch' the /conf directory by setting some data  so that events are triggered.
    */
-  private void registerConfListener() {
+  protected void registerConfListener() {
     if (!(resourceLoader instanceof ZkSolrResourceLoader)) return;
     final ZkSolrResourceLoader zkSolrResourceLoader = (ZkSolrResourceLoader) resourceLoader;
     if (zkSolrResourceLoader != null)

--- a/solr/core/src/java/org/apache/solr/core/SolrCoreProxy.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCoreProxy.java
@@ -86,7 +86,7 @@ public class SolrCoreProxy extends SolrCore {
   protected void closeSearchExecutor() {
     try {
       openSearcherLock.lock();
-      if (searcherExecutor != null) {
+      if (searcherExecutor != null && searcherExecutorFuture != null) {
         searcherExecutorFuture.get(60, TimeUnit.SECONDS);
       }
     } catch (Throwable e) {
@@ -98,5 +98,9 @@ public class SolrCoreProxy extends SolrCore {
       isSearchExecutorClosed = true;
       openSearcherLock.unlock();
     }
+  }
+
+  protected void registerConfListener() {
+    //we don't want register conf listener for proxy core
   }
 }

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -114,7 +114,7 @@ import org.slf4j.LoggerFactory;
  */
 @Slow
 public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTestBase {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @BeforeClass
   public static void beforeFullSolrCloudTest() {


### PR DESCRIPTION

1. Now overseer is disabled for query aggregator nodes
2. updated logic of reconnect for query aggregator nodes
 - first set watches for QA nodes
 - Then join ths QA node
3. Now SolrQuery Proxy not register for config updates.
4. added test for it