### PR TITLE
Disable overseer for QA, Updated reconnect and disable config listen…

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/QueryAggregatorZKController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/QueryAggregatorZKController.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.cloud;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.solr.client.solrj.cloud.NodeStateProvider;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.cloud.BeforeReconnect;
+import org.apache.solr.common.cloud.ConnectionManager;
+import org.apache.solr.common.cloud.DefaultConnectionStrategy;
+import org.apache.solr.common.cloud.OnReconnect;
+import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.solr.common.cloud.ZkACLProvider;
+import org.apache.solr.common.cloud.ZooKeeperException;
+import org.apache.solr.core.CloudConfig;
+import org.apache.solr.core.CoreContainer;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class QueryAggregatorZKController extends ZkController {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  public QueryAggregatorZKController(final CoreContainer cc, String zkServerAddress, int zkClientConnectTimeout, CloudConfig cloudConfig, final CurrentCoreDescriptorProvider registerOnReconnect)
+      throws InterruptedException, TimeoutException, IOException {
+    super(cc, zkServerAddress, zkClientConnectTimeout, cloudConfig, registerOnReconnect);
+  }
+
+  protected ZkDistributedQueue initOverseerJobQueue() {
+    return null;
+  }
+
+  protected OverseerTaskQueue initOverseerTaskQueue() {
+    return null;
+  }
+
+  protected OverseerTaskQueue initOverseerConfigSetQueue() {
+    return null;
+  }
+
+  protected NodeStateProvider getNodeStateProvider() {
+    return null;
+  }
+
+  protected SolrZkClient getSolrZkClient(int zkClientConnectTimeout,
+                                         CurrentCoreDescriptorProvider registerOnReconnect,
+                                         DefaultConnectionStrategy strat,
+                                         ZkACLProvider zkACLProvider) {
+    return new SolrZkClient(zkServerAddress, clientTimeout, zkClientConnectTimeout, strat,
+        // on reconnect, reload cloud info
+        new OnReconnect() {
+
+          @Override
+          public void command() throws KeeperException.SessionExpiredException {
+            log.info("ZooKeeper session re-connected ... refreshing core states after session expiration.");
+            try {
+              zkStateReader.createClusterStateWatchersAndUpdate();
+              createEphemeralLiveQueryNode();
+            } catch (Exception e) {
+              SolrException.log(log, "", e);
+              throw new ZooKeeperException(
+                  SolrException.ErrorCode.SERVER_ERROR, "", e);
+            }
+          }
+
+        }, new BeforeReconnect() {
+
+      @Override
+      public void command() {
+
+      }
+    }, zkACLProvider, new ConnectionManager.IsClosed() {
+
+      @Override
+      public boolean isClosed() {
+        return cc.isShutDown();
+      }
+    });
+  }
+}

--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -505,7 +505,7 @@ public class ZkController implements Closeable {
         this.overseerConfigSetQueue = null;
     }
 
-    this.sysPropsCacher = new NodesSysPropsCacher(getSolrCloudManager().getNodeStateProvider(),
+    this.sysPropsCacher = new NodesSysPropsCacher( cc.isQueryAggregator() ? null : getSolrCloudManager().getNodeStateProvider(),
         getNodeName(), zkStateReader);
 
     assert ObjectReleaseTracker.track(this);

--- a/solr/core/src/java/org/apache/solr/core/ConfigSetService.java
+++ b/solr/core/src/java/org/apache/solr/core/ConfigSetService.java
@@ -109,7 +109,7 @@ public abstract class ConfigSetService {
    */
   public ConfigSetService(SolrResourceLoader loader, boolean shareSchema) {
     this.parentLoader = loader;
-    this.schemaCache = (shareSchema || Boolean.getBoolean("shareSchema")) ? Caffeine.newBuilder().weakValues().build() : null;
+    this.schemaCache = shareSchema ? Caffeine.newBuilder().weakValues().build() : null;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/core/ConfigSetService.java
+++ b/solr/core/src/java/org/apache/solr/core/ConfigSetService.java
@@ -109,7 +109,7 @@ public abstract class ConfigSetService {
    */
   public ConfigSetService(SolrResourceLoader loader, boolean shareSchema) {
     this.parentLoader = loader;
-    this.schemaCache = shareSchema ? Caffeine.newBuilder().weakValues().build() : null;
+    this.schemaCache = (shareSchema || Boolean.getBoolean("shareSchema")) ? Caffeine.newBuilder().weakValues().build() : null;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -872,42 +872,44 @@ public class CoreContainer {
         SolrMetricManager.mkName("coreLoadExecutor", SolrInfoBean.Category.CONTAINER.toString(), "threadPool"));
     final List<Future<SolrCore>> futures = new ArrayList<>();
     try {
-      List<CoreDescriptor> cds = coresLocator.discover(this);
-      cds = CoreSorter.sortCores(this, cds);
-      checkForDuplicateCoreNames(cds);
-      status |= CORE_DISCOVERY_COMPLETE;
+      if (!isQueryAggregator) {
+        List<CoreDescriptor> cds = coresLocator.discover(this);
+        cds = CoreSorter.sortCores(this, cds);
+        checkForDuplicateCoreNames(cds);
+        status |= CORE_DISCOVERY_COMPLETE;
 
-      for (final CoreDescriptor cd : cds) {
-        if (cd.isTransient() || !cd.isLoadOnStartup()) {
-          solrCores.addCoreDescriptor(cd);
-        } else if (asyncSolrCoreLoad) {
-          solrCores.markCoreAsLoading(cd);
-        }
-        if (cd.isLoadOnStartup()) {
-          futures.add(coreLoadExecutor.submit(() -> {
-            SolrCore core;
-            try {
-              if (zkSys.getZkController() != null) {
-                zkSys.getZkController().throwErrorIfReplicaReplaced(cd);
+        for (final CoreDescriptor cd : cds) {
+          if (cd.isTransient() || !cd.isLoadOnStartup()) {
+            solrCores.addCoreDescriptor(cd);
+          } else if (asyncSolrCoreLoad) {
+            solrCores.markCoreAsLoading(cd);
+          }
+          if (cd.isLoadOnStartup()) {
+            futures.add(coreLoadExecutor.submit(() -> {
+              SolrCore core;
+              try {
+                if (zkSys.getZkController() != null) {
+                  zkSys.getZkController().throwErrorIfReplicaReplaced(cd);
+                }
+                solrCores.waitAddPendingCoreOps(cd.getName());
+                core = createFromDescriptor(cd, false, false);
+              } finally {
+                solrCores.removeFromPendingOps(cd.getName());
+                if (asyncSolrCoreLoad) {
+                  solrCores.markCoreAsNotLoading(cd);
+                }
               }
-              solrCores.waitAddPendingCoreOps(cd.getName());
-              core = createFromDescriptor(cd, false, false);
-            } finally {
-              solrCores.removeFromPendingOps(cd.getName());
-              if (asyncSolrCoreLoad) {
-                solrCores.markCoreAsNotLoading(cd);
+              try {
+                zkSys.registerInZk(core, true, false);
+              } catch (RuntimeException e) {
+                SolrException.log(log, "Error registering SolrCore", e);
               }
-            }
-            try {
-              zkSys.registerInZk(core, true, false);
-            } catch (RuntimeException e) {
-              SolrException.log(log, "Error registering SolrCore", e);
-            }
-            return core;
-          }));
+              return core;
+            }));
+          }
         }
+
       }
-
 
       // Start the background thread
       backgroundCloser = new CloserThread(this, solrCores, cfg);

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -3129,7 +3129,7 @@ public class SolrCore implements SolrInfoBean, SolrMetricProducer, Closeable {
    * there is no event fired when children are modified. So , we expect everyone
    * to 'touch' the /conf directory by setting some data  so that events are triggered.
    */
-  private void registerConfListener() {
+  protected void registerConfListener() {
     if (!(resourceLoader instanceof ZkSolrResourceLoader)) return;
     final ZkSolrResourceLoader zkSolrResourceLoader = (ZkSolrResourceLoader) resourceLoader;
     if (zkSolrResourceLoader != null)

--- a/solr/core/src/java/org/apache/solr/core/SolrCoreProxy.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCoreProxy.java
@@ -85,7 +85,7 @@ public class SolrCoreProxy extends SolrCore {
   protected void closeSearchExecutor() {
     try {
       openSearcherLock.lock();
-      if (searcherExecutor != null) {
+      if (searcherExecutor != null && searcherExecutorFuture != null) {
         searcherExecutorFuture.get(60, TimeUnit.SECONDS);
       }
     } catch (Throwable e) {
@@ -97,5 +97,9 @@ public class SolrCoreProxy extends SolrCore {
       isSearchExecutorClosed = true;
       openSearcherLock.unlock();
     }
+  }
+
+  protected void registerConfListener() {
+    //we don't want register conf listener for proxy core
   }
 }

--- a/solr/core/src/java/org/apache/solr/core/ZkContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/ZkContainer.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.cloud.CurrentCoreDescriptorProvider;
+import org.apache.solr.cloud.QueryAggregatorZKController;
 import org.apache.solr.cloud.SolrZkServer;
 import org.apache.solr.cloud.ZkController;
 import org.apache.solr.common.AlreadyClosedException;
@@ -129,14 +130,25 @@ public class ZkContainer {
           throw new ZooKeeperException(SolrException.ErrorCode.SERVER_ERROR,
               "A chroot was specified in ZkHost but the znode doesn't exist. " + zookeeperHost);
         }
-        zkController = new ZkController(cc, zookeeperHost, zkClientConnectTimeout, config,
-            new CurrentCoreDescriptorProvider() {
+        if (cc.isQueryAggregator()) {
+          zkController = new QueryAggregatorZKController(cc, zookeeperHost, zkClientConnectTimeout, config,
+              new CurrentCoreDescriptorProvider() {
 
-              @Override
-              public List<CoreDescriptor> getCurrentDescriptors() {
-                return cc.getCores().stream().map(SolrCore::getCoreDescriptor).collect(Collectors.toList());
-              }
-            });
+                @Override
+                public List<CoreDescriptor> getCurrentDescriptors() {
+                  return cc.getCores().stream().map(SolrCore::getCoreDescriptor).collect(Collectors.toList());
+                }
+              });
+        } else {
+          zkController = new ZkController(cc, zookeeperHost, zkClientConnectTimeout, config,
+              new CurrentCoreDescriptorProvider() {
+
+                @Override
+                public List<CoreDescriptor> getCurrentDescriptors() {
+                  return cc.getCores().stream().map(SolrCore::getCoreDescriptor).collect(Collectors.toList());
+                }
+              });
+        }
 
 
         if (zkRun != null) {

--- a/solr/core/src/test/org/apache/solr/core/SolrCoreProxyTest.java
+++ b/solr/core/src/test/org/apache/solr/core/SolrCoreProxyTest.java
@@ -71,7 +71,7 @@ public class SolrCoreProxyTest extends AbstractFullDistribZkTestBase {
     assertTrue("Query nodes should contain query node.", queryNodes.contains(queryNodeContainer.getZkController().getNodeName()));
     assertTrue("There must be some live nodes.", liveNodes.size() > 0);
     assertFalse("Query node should not register in live nodes.", liveNodes.contains(queryNodeContainer.getZkController().getNodeName()));
-
+    assertTrue("Collection should have one slice.", clusterState.getCollection(collectionName).getSlices().size() == 1);
 
     SolrCore core = queryNodeContainer.getCore(collectionName);
 
@@ -102,17 +102,43 @@ public class SolrCoreProxyTest extends AbstractFullDistribZkTestBase {
     try {
       System.setProperty("solr.test.sys.prop1", "propone");
       System.setProperty("solr.test.sys.prop2", "proptwo");
-
+      ClusterState preSplitClusterState = queryNodeContainer.getZkController().getClusterState();
       verifyCoreReloadAfterSchemaConfigUpdate(collectionName);
-      verifyCollectionShards(collectionName);
+      verifyCollectionShardSplit(collectionName);
       verifyCollectionListenerInstalled(collectionName);
-      log.info("restarting zookeeper ");
+      ClusterState postSplitClusterState = queryNodeContainer.getZkController().getClusterState();
+
+      log.info("restarting zookeeper================================ ");
       WatchedEvent watchedEvent = new WatchedEvent(Watcher.Event.EventType.ChildWatchRemoved, Watcher.Event.KeeperState.Expired, "/solr/live_query_node");
       queryNodeContainer.getZkController().getZkClient().getConnectionManager().process(watchedEvent);
-      log.info("restarted zookeeper ");
-      queryDocs(queryNodeUrl, collectionName, 10);
+      log.info("restarted zookeeper ======================================================== ");
+
+      ClusterState postZkReconnectClusterState = queryNodeContainer.getZkController().getClusterState();
+
+      //collection state should be same
+      assertTrue(postSplitClusterState.getCollection(collectionName).equals(postZkReconnectClusterState.getCollection(collectionName)));
+      //collection object should be same
+      DocCollection preC = postSplitClusterState.getCollection(collectionName);
+      DocCollection postC = postZkReconnectClusterState.getCollection(collectionName);
+      assertTrue( preC == postC);
+
+      //add more docs after zk disconnect
+      addDocs(ingestNodeUrl, collectionName, 10);
+      //total results should be 20
+      queryDocs(queryNodeUrl, collectionName, 20);
+
       verifyCollectionListenerInstalled(collectionName);
-      log.info("verifyCollectionListenerInstalled ");
+
+      //do again split and verify the data
+      verifyCollectionShardSplitAfterZkDisconnect(collectionName);
+      DocCollection postSplitC = queryNodeContainer.getZkController().getClusterState().getCollection(collectionName);
+      assertTrue(!postC.equals(postSplitC));
+      assertTrue(postC != postSplitC);
+      //add more docs after split
+      addDocs(ingestNodeUrl, collectionName, 10);
+      //total results should be 30
+      queryDocs(queryNodeUrl, collectionName, 30);
+
       verifyDeleteCollection(collectionName);
     } finally {
       System.clearProperty("solr.test.sys.prop1");
@@ -138,7 +164,7 @@ public class SolrCoreProxyTest extends AbstractFullDistribZkTestBase {
     assertTrue(currentCore == newCore);
   }
 
-  private void verifyCollectionShards(final String collection) throws Exception {
+  private void verifyCollectionShardSplit(final String collection) throws Exception {
     CoreContainer queryAggregatorContainer = getQueryNodeContainer();
     ClusterState clusterState = queryAggregatorContainer.getZkController().getZkStateReader().getClusterState();
     DocCollection docCollection = clusterState.getCollection(collection);
@@ -156,6 +182,26 @@ public class SolrCoreProxyTest extends AbstractFullDistribZkTestBase {
     assertNotNull(collectionRef);
     assertFalse(collectionRef instanceof ZkStateReader.LazyCollectionRef);
     assertTrue("Collection now should have two slices", docCollection.getActiveSlices().size() == 2);
+  }
+
+  private void verifyCollectionShardSplitAfterZkDisconnect(final String collection) throws Exception {
+    CoreContainer queryAggregatorContainer = getQueryNodeContainer();
+    ClusterState clusterState = queryAggregatorContainer.getZkController().getZkStateReader().getClusterState();
+    DocCollection docCollection = clusterState.getCollection(collection);
+
+    assertTrue("Collection should have one slice", docCollection.getActiveSlices().size() == 2);
+
+    CollectionAdminRequest.SplitShard splitShard = CollectionAdminRequest.splitShard(collection);
+    splitShard.setShardName("shard1_0");
+    NamedList<Object> response = splitShard.process(cloudClient).getResponse();
+    assertNotNull(response.get("success"));
+    Thread.sleep(5000);
+    clusterState = queryAggregatorContainer.getZkController().getZkStateReader().getClusterState();
+    docCollection = clusterState.getCollection(collection);
+    ClusterState.CollectionRef collectionRef = clusterState.getCollectionStates().get(collection);
+    assertNotNull(collectionRef);
+    assertFalse(collectionRef instanceof ZkStateReader.LazyCollectionRef);
+    assertTrue("Collection now should have two slices", docCollection.getActiveSlices().size() == 3);
   }
 
   private void verifyCollectionListenerInstalled(final String collection) throws Exception {

--- a/solr/server/solr/solr.xml
+++ b/solr/server/solr/solr.xml
@@ -31,6 +31,7 @@
   <int name="maxBooleanClauses">${solr.max.booleanClauses:1024}</int>
   <str name="sharedLib">${solr.sharedLib:}</str>
   <str name="allowPaths">${solr.allowPaths:}</str>
+  <bool name="shareSchema">${shareSchema:false}</bool>
 
   <solrcloud>
 

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -731,6 +731,7 @@ public class ZkStateReader implements SolrCloseable {
           // Double check contains just to avoid allocating an object.
           LazyCollectionRef existing = lazyCollectionStates.get(coll);
           if (existing == null) {
+            log.info("adding coll " + coll, new RuntimeException("adding coll " + coll));
             lazyCollectionStates.putIfAbsent(coll, new LazyCollectionRef(coll));
           }
         }
@@ -831,6 +832,7 @@ public class ZkStateReader implements SolrCloseable {
           }
         }
         if (shouldFetch) {
+          log.info("fetching collection ", new RuntimeException("fetching collection " + collName));
           cachedDocCollection = getCollectionLive(ZkStateReader.this, collName);
           lastUpdateTime = System.nanoTime();
         }

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -597,23 +597,17 @@ public class ZkStateReader implements SolrCloseable {
   private void constructState(Set<String> changedCollections) {
 
     Set<String> liveNodes = this.liveNodes; // volatile read
-    log.info("collectionWatches size " + collectionWatches.size());
-    log.info("legacyCollectionStates size " + legacyCollectionStates.size());
-    log.info("watchedCollectionStates size " + watchedCollectionStates.size());
-    log.info("lazyCollectionStates size " + lazyCollectionStates.size());
     // Legacy clusterstate is authoritative, for backwards compatibility.
     // To move a collection's state to format2, first create the new state2 format node, then remove legacy entry.
     Map<String, ClusterState.CollectionRef> result = new LinkedHashMap<>(legacyCollectionStates);
 
     // Add state format2 collections, but don't override legacy collection states.
     for (Map.Entry<String, DocCollection> entry : watchedCollectionStates.entrySet()) {
-      log.info("construct state: watch collection " + entry.getKey());
       result.putIfAbsent(entry.getKey(), new ClusterState.CollectionRef(entry.getValue()));
     }
 
     // Finally, add any lazy collections that aren't already accounted for.
     for (Map.Entry<String, LazyCollectionRef> entry : lazyCollectionStates.entrySet()) {
-      log.info("construct state: lazy collection " + entry.getKey());
       result.putIfAbsent(entry.getKey(), entry.getValue());
     }
 
@@ -2140,7 +2134,6 @@ public class ZkStateReader implements SolrCloseable {
           if (log.isDebugEnabled()) {
             log.debug("Add data for [{}] ver [{}]", coll, newState.getZNodeVersion());
           }
-          log.info("Add data for [{}] ver [{}]", coll, newState.getZNodeVersion());
           updated = true;
           break;
         }
@@ -2157,7 +2150,6 @@ public class ZkStateReader implements SolrCloseable {
           if (log.isDebugEnabled()) {
             log.debug("Updating data for [{}] from [{}] to [{}]", coll, oldState.getZNodeVersion(), newState.getZNodeVersion());
           }
-          log.info("Updating data for [{}] from [{}] to [{}]", coll, oldState.getZNodeVersion(), newState.getZNodeVersion());
           updated = true;
           break;
         }

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -831,7 +831,6 @@ public class ZkStateReader implements SolrCloseable {
           }
         }
         if (shouldFetch) {
-          //log.info("fetching collection ", new RuntimeException("fetching collection " + collName));
           cachedDocCollection = getCollectionLive(ZkStateReader.this, collName);
           lastUpdateTime = System.nanoTime();
         }

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -116,7 +116,7 @@ import org.slf4j.LoggerFactory;
  */
 @Slow
 public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTestBase {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @BeforeClass
   public static void beforeFullSolrCloudTest() {


### PR DESCRIPTION
1. Disabled overseer membership for query aggregator node.
2. updated logic of reconnect for query aggregator node
     - first set watches for QA nodes
     - Then join the QA node
3. Now Solr proxy doesn't register zk watch for config updates. 
4. QA node subscribe for zk-collection watch. Fixed related issue
5. Added 'shareSchema` flag to intern solr schema.
6. Now QA node doesn't initialize the Proxy core while restarting the node.