### PR TITLE
Share class loader if plugin jar directories are same

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -705,9 +705,6 @@ public class CoreContainer {
         }
       }
     }
-    if (modified) {
-      loader.reloadLuceneSPI();
-    }
 
     packageStoreAPI = new PackageStoreAPI(this);
     containerHandlers.getApiBag().registerObject(packageStoreAPI.readAPI);

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -882,7 +882,6 @@ public class SolrConfig implements MapSerializable {
 
     if (!urls.isEmpty()) {
       loader.addToClassLoader(urls);
-      loader.reloadLuceneSPI();
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/core/SolrResourceLoader.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrResourceLoader.java
@@ -188,6 +188,16 @@ public class SolrResourceLoader implements ResourceLoader, Closeable, SolrClassL
     private final List<URL> urls;
 
     public URLListWrapper(List<URL> urls) {
+      if (urls == null) {
+        urls = Collections.<URL>emptyList();
+      }
+
+      Collections.sort(urls, new Comparator<URL>() {
+        @Override
+        public int compare(URL o1, URL o2) {
+          return o1.toString().compareTo(o2.toString());
+        }
+      });
       this.urls = urls;
       this.hashcode = urls.hashCode();
     }

--- a/solr/core/src/java/org/apache/solr/core/SolrResourceLoader.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrResourceLoader.java
@@ -930,6 +930,7 @@ public class SolrResourceLoader implements ResourceLoader, Closeable, SolrClassL
   @Override
   public void close() throws IOException {
     IOUtils.close(classLoader);
+    classLoaderCache.clear();
   }
   public List<SolrInfoBean> getInfoMBeans(){
     return Collections.unmodifiableList(infoMBeans);


### PR DESCRIPTION
Creating a common classloader for solrcore if plugin jar directories are same. This reduces lot of memory for QA nodes, also it should help in regular solr nodes. (we bundle plugin with solr but with zk should work?)