### PR TITLE
Added ability to create metrics for needed classes only

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -111,6 +111,7 @@ import org.apache.solr.handler.admin.SecurityConfHandlerZk;
 import org.apache.solr.handler.admin.ZookeeperInfoHandler;
 import org.apache.solr.handler.admin.ZookeeperReadAPI;
 import org.apache.solr.handler.admin.ZookeeperStatusHandler;
+import org.apache.solr.handler.component.SearchHandler;
 import org.apache.solr.handler.component.ShardHandlerFactory;
 import org.apache.solr.handler.sql.CalciteSolrDriver;
 import org.apache.solr.logging.LogWatcher;
@@ -713,7 +714,12 @@ public class CoreContainer {
     containerHandlers.getApiBag().registerObject(packageStoreAPI.readAPI);
     containerHandlers.getApiBag().registerObject(packageStoreAPI.writeAPI);
 
-    metricManager = new SolrMetricManager(loader, cfg.getMetricsConfig());
+    Set<Class> whiteList = null;
+    if(isQueryAggregator) {
+      whiteList = new HashSet<>();
+      whiteList.add(SearchHandler.class);
+    }
+    metricManager = new SolrMetricManager(loader, cfg.getMetricsConfig(), whiteList);
     String registryName = SolrMetricManager.getRegistryName(SolrInfoBean.Group.node);
     solrMetricsContext = new SolrMetricsContext(metricManager, registryName, metricTag);
 

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -616,7 +616,7 @@ public class SolrXmlConfig {
     }
     // if there's an MBean server running but there was no JMX reporter then add a default one
     MBeanServer mBeanServer = JmxUtil.findFirstMBeanServer();
-    if (mBeanServer != null && !hasJmxReporter) {
+    if (Boolean.getBoolean("EnableJMX") && mBeanServer != null && !hasJmxReporter) {
       log.info("MBean server found: {}, but no JMX reporters were configured - adding default JMX reporter.", mBeanServer);
       Map<String,Object> attributes = new HashMap<>();
       attributes.put("name", "default");

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
@@ -116,7 +116,10 @@ public class SolrMetricManager {
   private final MetricRegistry.MetricSupplier<Timer> timerSupplier;
   private final MetricRegistry.MetricSupplier<Histogram> histogramSupplier;
 
+  private final Set<Class> whiteList;
+
   public SolrMetricManager() {
+    whiteList = null;
     metricsConfig = new MetricsConfig.MetricsConfigBuilder().build();
     counterSupplier = MetricSuppliers.counterSupplier(null, null);
     meterSupplier = MetricSuppliers.meterSupplier(null, null);
@@ -124,8 +127,9 @@ public class SolrMetricManager {
     histogramSupplier = MetricSuppliers.histogramSupplier(null, null);
   }
 
-  public SolrMetricManager(SolrResourceLoader loader, MetricsConfig metricsConfig) {
+  public SolrMetricManager(SolrResourceLoader loader, MetricsConfig metricsConfig, Set<Class> whiteList) {
     this.metricsConfig = metricsConfig;
+    this.whiteList = whiteList;
     counterSupplier = MetricSuppliers.counterSupplier(loader, metricsConfig.getCounterSupplier());
     meterSupplier = MetricSuppliers.meterSupplier(loader, metricsConfig.getMeterSupplier());
     timerSupplier = MetricSuppliers.timerSupplier(loader, metricsConfig.getTimerSupplier());
@@ -662,7 +666,12 @@ public class SolrMetricManager {
     if (info != null) {
       info.registerMetricName(name);
     }
-    return registry(registry).meter(name, meterSupplier);
+    MetricRegistry.MetricSupplier<Meter> meterMetricSupplier = meterSupplier;
+    if (whiteList != null) {
+      if ( info == null || !whiteList.contains(info.getClass()))
+        meterMetricSupplier = MetricSuppliers.NoOpMeterSupplier.INSTANCE;
+    }
+    return registry(registry).meter(name, meterMetricSupplier);
   }
 
   /**
@@ -679,7 +688,12 @@ public class SolrMetricManager {
     if (info != null) {
       info.registerMetricName(name);
     }
-    return registry(registry).timer(name, timerSupplier);
+    MetricRegistry.MetricSupplier<Timer> timerMetricSupplier = timerSupplier;
+    if (whiteList != null) {
+      if ( info == null || !whiteList.contains(info.getClass()))
+        timerMetricSupplier = MetricSuppliers.NoOpTimerSupplier.INSTANCE;
+    }
+    return registry(registry).timer(name, timerMetricSupplier);
   }
 
   /**
@@ -696,7 +710,12 @@ public class SolrMetricManager {
     if (info != null) {
       info.registerMetricName(name);
     }
-    return registry(registry).counter(name, counterSupplier);
+    MetricRegistry.MetricSupplier<Counter> counterMetricSupplier = counterSupplier;
+    if (whiteList != null) {
+      if ( info == null || !whiteList.contains(info.getClass()))
+        counterMetricSupplier = MetricSuppliers.NoOpCounterSupplier.INSTANCE;
+    }
+    return registry(registry).counter(name, counterMetricSupplier);
   }
 
   /**
@@ -713,7 +732,12 @@ public class SolrMetricManager {
     if (info != null) {
       info.registerMetricName(name);
     }
-    return registry(registry).histogram(name, histogramSupplier);
+    MetricRegistry.MetricSupplier<Histogram> histogramMetricSupplier = histogramSupplier;
+    if (whiteList != null) {
+      if ( info == null || !whiteList.contains(info.getClass()))
+        histogramMetricSupplier = MetricSuppliers.NoOpHistogramSupplier.INSTANCE;
+    }
+    return registry(registry).histogram(name, histogramMetricSupplier);
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
@@ -667,9 +667,8 @@ public class SolrMetricManager {
       info.registerMetricName(name);
     }
     MetricRegistry.MetricSupplier<Meter> meterMetricSupplier = meterSupplier;
-    if (whiteList != null) {
-      if ( info == null || !whiteList.contains(info.getClass()))
-        meterMetricSupplier = MetricSuppliers.NoOpMeterSupplier.INSTANCE;
+    if (ignoreMetrics(info)) {
+      meterMetricSupplier = MetricSuppliers.NoOpMeterSupplier.INSTANCE;
     }
     return registry(registry).meter(name, meterMetricSupplier);
   }
@@ -689,9 +688,8 @@ public class SolrMetricManager {
       info.registerMetricName(name);
     }
     MetricRegistry.MetricSupplier<Timer> timerMetricSupplier = timerSupplier;
-    if (whiteList != null) {
-      if ( info == null || !whiteList.contains(info.getClass()))
-        timerMetricSupplier = MetricSuppliers.NoOpTimerSupplier.INSTANCE;
+    if (ignoreMetrics(info)) {
+      timerMetricSupplier = MetricSuppliers.NoOpTimerSupplier.INSTANCE;
     }
     return registry(registry).timer(name, timerMetricSupplier);
   }
@@ -711,9 +709,8 @@ public class SolrMetricManager {
       info.registerMetricName(name);
     }
     MetricRegistry.MetricSupplier<Counter> counterMetricSupplier = counterSupplier;
-    if (whiteList != null) {
-      if ( info == null || !whiteList.contains(info.getClass()))
-        counterMetricSupplier = MetricSuppliers.NoOpCounterSupplier.INSTANCE;
+    if (ignoreMetrics(info)) {
+      counterMetricSupplier = MetricSuppliers.NoOpCounterSupplier.INSTANCE;
     }
     return registry(registry).counter(name, counterMetricSupplier);
   }
@@ -733,9 +730,8 @@ public class SolrMetricManager {
       info.registerMetricName(name);
     }
     MetricRegistry.MetricSupplier<Histogram> histogramMetricSupplier = histogramSupplier;
-    if (whiteList != null) {
-      if ( info == null || !whiteList.contains(info.getClass()))
-        histogramMetricSupplier = MetricSuppliers.NoOpHistogramSupplier.INSTANCE;
+    if (ignoreMetrics(info)) {
+      histogramMetricSupplier = MetricSuppliers.NoOpHistogramSupplier.INSTANCE;
     }
     return registry(registry).histogram(name, histogramMetricSupplier);
   }
@@ -797,7 +793,7 @@ public class SolrMetricManager {
   }
   @SuppressWarnings({"unchecked", "rawtypes"})
   public void registerGauge(SolrInfoBean info, String registry, Gauge<?> gauge, String tag, boolean force, String metricName, String... metricPath) {
-    if (!metricsConfig.isEnabled()) {
+    if (!metricsConfig.isEnabled() || ignoreMetrics(info)) {
       gauge = MetricSuppliers.getNoOpGauge(gauge);
     }
     registerMetric(info, registry, new GaugeWrapper(gauge, tag), force, metricName, metricPath);
@@ -1077,6 +1073,15 @@ public class SolrMetricManager {
     } finally {
       reportersLock.unlock();
     }
+  }
+
+  private boolean ignoreMetrics(SolrInfoBean info) {
+    if (whiteList != null && !whiteList.isEmpty()) {
+      if (info == null || !whiteList.contains(info.getClass())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/solr/core/src/test/org/apache/solr/metrics/MetricsConfigTest.java
+++ b/solr/core/src/test/org/apache/solr/metrics/MetricsConfigTest.java
@@ -60,7 +60,7 @@ public class MetricsConfigTest extends SolrTestCaseJ4 {
   @Test
   public void testDefaults() throws Exception {
     NodeConfig cfg = loadNodeConfig("solr-metricsconfig.xml");
-    SolrMetricManager mgr = new SolrMetricManager(cfg.getSolrResourceLoader(), cfg.getMetricsConfig());
+    SolrMetricManager mgr = new SolrMetricManager(cfg.getSolrResourceLoader(), cfg.getMetricsConfig(), null);
     assertTrue(mgr.getCounterSupplier() instanceof MetricSuppliers.DefaultCounterSupplier);
     assertTrue(mgr.getMeterSupplier() instanceof MetricSuppliers.DefaultMeterSupplier);
     assertTrue(mgr.getTimerSupplier() instanceof MetricSuppliers.DefaultTimerSupplier);
@@ -78,7 +78,7 @@ public class MetricsConfigTest extends SolrTestCaseJ4 {
     System.setProperty("histogram.window", "600");
     System.setProperty("histogram.reservoir", SlidingTimeWindowReservoir.class.getName());
     NodeConfig cfg = loadNodeConfig("solr-metricsconfig.xml");
-    SolrMetricManager mgr = new SolrMetricManager(cfg.getSolrResourceLoader(), cfg.getMetricsConfig());
+    SolrMetricManager mgr = new SolrMetricManager(cfg.getSolrResourceLoader(), cfg.getMetricsConfig(), null);
     assertTrue(mgr.getCounterSupplier() instanceof MetricSuppliers.DefaultCounterSupplier);
     assertTrue(mgr.getMeterSupplier() instanceof MetricSuppliers.DefaultMeterSupplier);
     assertTrue(mgr.getTimerSupplier() instanceof MetricSuppliers.DefaultTimerSupplier);
@@ -96,7 +96,7 @@ public class MetricsConfigTest extends SolrTestCaseJ4 {
     System.setProperty("timer.class", MockTimerSupplier.class.getName());
     System.setProperty("histogram.class", MockHistogramSupplier.class.getName());
     NodeConfig cfg = loadNodeConfig("solr-metricsconfig.xml");
-    SolrMetricManager mgr = new SolrMetricManager(cfg.getSolrResourceLoader(), cfg.getMetricsConfig());
+    SolrMetricManager mgr = new SolrMetricManager(cfg.getSolrResourceLoader(), cfg.getMetricsConfig(), null);
     assertTrue(mgr.getCounterSupplier() instanceof MockCounterSupplier);
     assertTrue(mgr.getMeterSupplier() instanceof MockMeterSupplier);
     assertTrue(mgr.getTimerSupplier() instanceof MockTimerSupplier);
@@ -121,7 +121,7 @@ public class MetricsConfigTest extends SolrTestCaseJ4 {
   public void testDisabledMetrics() throws Exception {
     System.setProperty("metricsEnabled", "false");
     NodeConfig cfg = loadNodeConfig("solr-metricsconfig.xml");
-    SolrMetricManager mgr = new SolrMetricManager(cfg.getSolrResourceLoader(), cfg.getMetricsConfig());
+    SolrMetricManager mgr = new SolrMetricManager(cfg.getSolrResourceLoader(), cfg.getMetricsConfig(), null);
     assertTrue(mgr.getCounterSupplier() instanceof MetricSuppliers.NoOpCounterSupplier);
     assertTrue(mgr.getMeterSupplier() instanceof MetricSuppliers.NoOpMeterSupplier);
     assertTrue(mgr.getTimerSupplier() instanceof MetricSuppliers.NoOpTimerSupplier);
@@ -132,7 +132,7 @@ public class MetricsConfigTest extends SolrTestCaseJ4 {
   @Test
   public void testMissingValuesConfig() throws Exception {
     NodeConfig cfg = loadNodeConfig("solr-metricsconfig1.xml");
-    SolrMetricManager mgr = new SolrMetricManager(cfg.getSolrResourceLoader(), cfg.getMetricsConfig());
+    SolrMetricManager mgr = new SolrMetricManager(cfg.getSolrResourceLoader(), cfg.getMetricsConfig(), null);
     assertEquals("nullNumber", null, mgr.nullNumber());
     assertEquals("notANumber", -1, mgr.notANumber());
     assertEquals("nullNumber", "", mgr.nullString());

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -276,7 +276,7 @@ public abstract class SolrTestCaseJ4 extends SolrTestCase {
     // backcompat create it now in case any third party tests expect initCoreDataDir to be
     // non-null after calling setupTestCases()
     initAndGetDataDir();
-
+    System.setProperty("EnableJMX", "true");
     System.setProperty("solr.zkclienttimeout", "90000");
 
     System.setProperty("solr.httpclient.retries", "1");


### PR DESCRIPTION
1. Added whitelist in SolrMetricsManager to create metrics for needed classes. that reduces lots of memory in QA nodes.
2. Also, diasable jmx reporter, which consumes lots of memory