### PR TITLE
Flag exception during core creation if the node defined in state.json is not the same as current node

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -2006,9 +2006,9 @@ public class ZkController implements Closeable {
             errorMessage.set("coreNodeName " + coreNodeName + " does not exist in shard " + cloudDesc.getShardId() +
                 ", ignore the exception if the replica was deleted");
             return false;
-          } else if (replica.getNodeName().equals(getNodeName())) {
-            errorMessage.set("coreNodeName " + coreNodeName + " exist in shard " + cloudDesc.getShardId() +
-                ", but the node name in cluster collection state [" + replica.getNodeName() + "] is different from current node [" + getNodeName() + "]");
+          } else if (!replica.getNodeName().equals(getNodeName())) {
+            errorMessage.set("collection [" + replica.getCollection() + "] with coreNodeName [" + coreNodeName + "] exist in shard [" + cloudDesc.getShardId() +
+                "], but the node name in cluster collection state [" + replica.getNodeName() + "] is different from current node [" + getNodeName() + "]");
             return false;
           }
           return true;


### PR DESCRIPTION
## Description
It's found that our prod env have certain data nodes have "ghost replicas" that do not have data dir but has the core.properties file and core directory. Replica with same name is actually reside on a different node as defined in the `state.json`. Such "ghost replicas" can trigger  `DOWN` replica state being published, which the real replica (with same name) is actually healthy in another node.

More details of the issue can be found in https://app.shortcut.com/fullstory/story/217252/investigate-replica-that-failed-to-come-up-as-active-during-restart-deployment#activity-217734

## Solution
While we do not know the exact cause of those "ghost replicas" (probably from some migration hiccup during c82 creation?), it seems to be a rare occurrence for now (8 replicas in c82). 

Therefore we will add a new exception `InconsistentClusterStateException`, which would be thrown from `checkStateInZk` (along with some existing zk checks) if node name of a replica defined in state.json is different from the current node which tries to spin up such core. Such exception would interrupt the core creation, and no longer publish a `DOWN` state.

For now, we will NOT provide an cleanup in the Solr code, as this seems to be an edge case and cleanup (ie unload core and remove the physical directory) could be risky. 

Take note that we will probably still need to "clean up" those ghost replicas later on perhaps by manually purging them. 